### PR TITLE
Fix memory leaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,11 @@ class PQueue {
 			this.queue.dequeue()();
 		} else {
 			this._resolveEmpty();
+			this._resolveEmpty = () => {};
 
 			if (this._pendingCount === 0) {
 				this._resolveIdle();
+				this._resolveIdle = () => {};
 			}
 		}
 	}


### PR DESCRIPTION
## Env

- Node.js 8.4.0
- macOS 10.12.6
- p-queue 2.2.0

## Description

`onEmpty()` and `onIdle()` will cause memory leaks.

Here's an example:

**test.js**

```js
const PQueue = require('p-queue');
const delay = require('delay');
(async function () {
	const queue = new PQueue({ concurrency: 100 });
	for (let i = 0; i < 100000; i++) {
		queue.add(delay(1));
		await queue.onEmpty();
	}
	console.log('done');
}());
```
And run `node --stack_size=50 test.js`

**Before PR**

```
(node:4054) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): RangeError: Maximum call stack size exceeded
(node:4054) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:4054) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): RangeError: Maximum call stack size exceeded
(node:4054) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): RangeError: Maximum call stack size exceeded
(node:4054) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 4): RangeError: Maximum call stack size exceeded
...
```

**After PR**
```
done
```
