### PR TITLE
Add ability to queue sync/async mixed tasks

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -42,7 +42,7 @@ suite
 	.on('complete', function () {
 		console.log('Fastest is ' + this.filter('fastest').map('name'));
 	})
-.run({
-	defer: true,
-	async: true
-});
+	.run({
+		defer: true,
+		async: true
+	});

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ class PQueue {
 		this._queueClass = opts.queueClass;
 		this._pendingCount = 0;
 		this._concurrency = opts.concurrency;
-		this._paused = (opts.autoStart === false);
+		this._paused = opts.autoStart === false;
 		this._resolveEmpty = () => {};
 		this._resolveIdle = () => {};
 	}

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ class PQueue {
 		this._queueClass = opts.queueClass;
 		this._pendingCount = 0;
 		this._concurrency = opts.concurrency;
-		this._paused = opts.autoStart === false;
+		this._isPaused = opts.autoStart === false;
 		this._resolveEmpty = () => {};
 		this._resolveIdle = () => {};
 	}
@@ -75,7 +75,7 @@ class PQueue {
 	_next() {
 		this._pendingCount--;
 
-		if (!this._paused && this.queue.size > 0) {
+		if (!this._isPaused && this.queue.size > 0) {
 			this.queue.dequeue()();
 		} else {
 			this._resolveEmpty();
@@ -103,7 +103,7 @@ class PQueue {
 				);
 			};
 
-			if (!this._paused && this._pendingCount < this._concurrency) {
+			if (!this._isPaused && this._pendingCount < this._concurrency) {
 				run();
 			} else {
 				this.queue.enqueue(run, opts);
@@ -116,18 +116,18 @@ class PQueue {
 	}
 
 	start() {
-		if (!this._paused) {
+		if (!this._isPaused) {
 			return;
 		}
 
-		this._paused = false;
+		this._isPaused = false;
 		while (this.queue.size > 0 && this._pendingCount < this._concurrency) {
 			this.queue.dequeue()();
 		}
 	}
 
 	pause() {
-		this._paused = true;
+		this._isPaused = true;
 	}
 
 	clear() {

--- a/index.js
+++ b/index.js
@@ -79,9 +79,11 @@ class PQueue {
 			this.queue.dequeue()();
 		} else {
 			this._resolveEmpty();
+			this._resolveEmpty = () => {};
 
 			if (this._pendingCount === 0) {
 				this._resolveIdle();
+				this._resolveIdle = () => {};
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ class PQueue {
 			const run = () => {
 				this._pendingCount++;
 
-				fn().then(
+				Promise.resolve(fn()).then(
 					val => {
 						resolve(val);
 						this._next();

--- a/index.js
+++ b/index.js
@@ -171,6 +171,10 @@ class PQueue {
 	get pending() {
 		return this._pendingCount;
 	}
+
+	get isPaused() {
+		return this._isPaused;
+	}
 }
 
 module.exports = PQueue;

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ class PQueue {
 	constructor(opts) {
 		opts = Object.assign({
 			concurrency: Infinity,
+			autoStart: true,
 			queueClass: PriorityQueue
 		}, opts);
 
@@ -66,6 +67,7 @@ class PQueue {
 		this._queueClass = opts.queueClass;
 		this._pendingCount = 0;
 		this._concurrency = opts.concurrency;
+		this._paused = (opts.autoStart === false);
 		this._resolveEmpty = () => {};
 		this._resolveIdle = () => {};
 	}
@@ -73,7 +75,7 @@ class PQueue {
 	_next() {
 		this._pendingCount--;
 
-		if (this.queue.size > 0) {
+		if (!this._paused && this.queue.size > 0) {
 			this.queue.dequeue()();
 		} else {
 			this._resolveEmpty();
@@ -101,7 +103,7 @@ class PQueue {
 				);
 			};
 
-			if (this._pendingCount < this._concurrency) {
+			if (!this._paused && this._pendingCount < this._concurrency) {
 				run();
 			} else {
 				this.queue.enqueue(run, opts);
@@ -111,6 +113,21 @@ class PQueue {
 
 	addAll(fns, opts) {
 		return Promise.all(fns.map(fn => this.add(fn, opts)));
+	}
+
+	start() {
+		if (!this._paused) {
+			return;
+		}
+
+		this._paused = false;
+		while (this.queue.size > 0 && this._pendingCount < this._concurrency) {
+			this.queue.dequeue()();
+		}
+	}
+
+	pause() {
+		this._paused = true;
 	}
 
 	clear() {

--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-  "name": "p-queue",
-  "version": "2.3.0",
-  "description": "Promise queue with concurrency control",
-  "license": "MIT",
-  "repository": "sindresorhus/p-queue",
-  "author": {
-    "name": "Sindre Sorhus",
-    "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
-  },
-  "maintainers": [
-    {
-      "name": "Vsevolod Strukchinsky",
-      "email": "floatdrop@gmail.com",
-      "url": "github.com/floatdrop"
-    }
-  ],
-  "engines": {
-    "node": ">=4"
-  },
-  "scripts": {
-    "test": "xo && ava",
-    "bench": "node bench.js"
-  },
-  "files": [
-    "index.js"
-  ],
-  "keywords": [
-    "promise",
-    "queue",
-    "enqueue",
-    "limit",
-    "limited",
-    "concurrency",
-    "throttle",
-    "throat",
-    "rate",
-    "batch",
-    "ratelimit",
-    "priority",
-    "priorityqueue",
-    "fifo",
-    "job",
-    "task",
-    "async",
-    "await",
-    "promises",
-    "bluebird"
-  ],
-  "devDependencies": {
-    "ava": "*",
-    "benchmark": "^2.1.2",
-    "delay": "^2.0.0",
-    "in-range": "^1.0.0",
-    "random-int": "^1.0.0",
-    "time-span": "^2.0.0",
-    "xo": "*"
-  }
+	"name": "p-queue",
+	"version": "2.3.1",
+	"description": "Promise queue with concurrency control",
+	"license": "MIT",
+	"repository": "sindresorhus/p-queue",
+	"author": {
+		"name": "Sindre Sorhus",
+		"email": "sindresorhus@gmail.com",
+		"url": "sindresorhus.com"
+	},
+	"maintainers": [
+		{
+			"name": "Vsevolod Strukchinsky",
+			"email": "floatdrop@gmail.com",
+			"url": "github.com/floatdrop"
+		}
+	],
+	"engines": {
+		"node": ">=4"
+	},
+	"scripts": {
+		"test": "xo && ava",
+		"bench": "node bench.js"
+	},
+	"files": [
+		"index.js"
+	],
+	"keywords": [
+		"promise",
+		"queue",
+		"enqueue",
+		"limit",
+		"limited",
+		"concurrency",
+		"throttle",
+		"throat",
+		"rate",
+		"batch",
+		"ratelimit",
+		"priority",
+		"priorityqueue",
+		"fifo",
+		"job",
+		"task",
+		"async",
+		"await",
+		"promises",
+		"bluebird"
+	],
+	"devDependencies": {
+		"ava": "*",
+		"benchmark": "^2.1.2",
+		"delay": "^2.0.0",
+		"in-range": "^1.0.0",
+		"random-int": "^1.0.0",
+		"time-span": "^2.0.0",
+		"xo": "*"
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Concurrency limit.
 ##### autoStart
 
 Type: `boolean`<br>
-Default: `true`<br>
+Default: `true`
 
 Whether queue tasks within concurrency limit, are auto-executed as soon as they're added.
 

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,13 @@ Minimum: `1`
 
 Concurrency limit.
 
+##### autoStart
+
+Type: `boolean`<br>
+Default: `true`<br>
+
+Whether queue tasks within concurrency limit, are auto-executed as soon as they're added.
+
 ##### queueClass
 
 Type: `Function`
@@ -89,6 +96,14 @@ Priority of operation. Operations with greater priority will be scheduled first.
 
 Same as `.add()`, but accepts an array of async functions and returns a promise that resolves when all async functions are resolved.
 
+#### .pause()
+
+Put queue execution on hold.
+
+#### .start()
+
+Start (or resume) executing enqueued tasks within concurrency limit. No need to call this if queue is not paused (via `options.autoStart = false` or by `.pause()` method.)
+
 #### .onEmpty()
 
 Returns a promise that settles when the queue becomes empty.
@@ -113,6 +128,9 @@ Size of the queue.
 
 Number of pending promises.
 
+#### .isPaused
+
+Whether the queue is currently paused.
 
 ## Advanced example
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Promise queue with concurrency control
 
-Useful for rate-limiting async operations. For example, when interacting with a REST API or when doing CPU/memory intensive tasks.
+Useful for rate-limiting async (or sync) operations. For example, when interacting with a REST API or when doing CPU/memory intensive tasks.
 
 
 ## Install
@@ -73,7 +73,7 @@ Class with a `enqueue` and `dequeue` method, and a `size` getter. See the [Custo
 
 #### .add(fn, [options])
 
-Returns the promise returned by calling `fn`.
+Returns the promise or value returned by calling `fn`. This allows adding both sync and async tasks to the queue.
 
 ##### fn
 
@@ -94,7 +94,7 @@ Priority of operation. Operations with greater priority will be scheduled first.
 
 #### .addAll(fns, [options])
 
-Same as `.add()`, but accepts an array of async functions and returns a promise that resolves when all async functions are resolved.
+Same as `.add()`, but accepts an array of sync or async functions and returns a promise that resolves when all functions are resolved.
 
 #### .pause()
 

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ Class with a `enqueue` and `dequeue` method, and a `size` getter. See the [Custo
 
 #### .add(fn, [options])
 
-Returns the promise or value returned by calling `fn`. This allows adding both sync and async tasks to the queue.
+Adds a sync or async task to the queue. Always returns a promise.
 
 ##### fn
 

--- a/test.js
+++ b/test.js
@@ -209,3 +209,30 @@ test('.pause()', t => {
 	queue.clear();
 	t.is(queue.size, 0);
 });
+
+test('.add() sync/async mixed tasks', async t => {
+	const queue = new PQueue({concurrency: 1});
+	queue.add(() => 'sync 1');
+	queue.add(() => delay(1000));
+	queue.add(() => 'sync 2');
+	queue.add(() => fixture);
+	t.is(queue.size, 3);
+	t.is(queue.pending, 1);
+	await queue.onIdle();
+	t.is(queue.size, 0);
+	t.is(queue.pending, 0);
+});
+
+test('.addAll() sync/async mixed tasks', async t => {
+	const queue = new PQueue();
+	const fns = [
+		() => 'sync 1',
+		() => delay(2000),
+		() => 'sync 2',
+		async () => fixture
+	];
+	const p = queue.addAll(fns);
+	t.is(queue.size, 0);
+	t.is(queue.pending, 4);
+	t.deepEqual(await p, ['sync 1', undefined, 'sync 2', fixture]);
+});

--- a/test.js
+++ b/test.js
@@ -156,3 +156,50 @@ test('enforce number in options.concurrency', t => {
 	});
 	/* eslint-enable no-new */
 });
+
+test('autoStart: false', t => {
+	const queue = new PQueue({concurrency: 2, autoStart: false});
+
+	queue.add(() => delay(20000));
+	queue.add(() => delay(20000));
+	queue.add(() => delay(20000));
+	queue.add(() => delay(20000));
+	t.is(queue.size, 4);
+	t.is(queue.pending, 0);
+
+	queue.start();
+	t.is(queue.size, 2);
+	t.is(queue.pending, 2);
+
+	queue.clear();
+	t.is(queue.size, 0);
+});
+
+test('.pause()', t => {
+	const queue = new PQueue({concurrency: 2});
+
+	queue.pause();
+	queue.add(() => delay(20000));
+	queue.add(() => delay(20000));
+	queue.add(() => delay(20000));
+	queue.add(() => delay(20000));
+	queue.add(() => delay(20000));
+	t.is(queue.size, 5);
+	t.is(queue.pending, 0);
+
+	queue.start();
+	t.is(queue.size, 3);
+	t.is(queue.pending, 2);
+
+	queue.add(() => delay(20000));
+	queue.pause();
+	t.is(queue.size, 4);
+	t.is(queue.pending, 2);
+
+	queue.start();
+	t.is(queue.size, 4);
+	t.is(queue.pending, 2);
+
+	queue.clear();
+	t.is(queue.size, 0);
+});

--- a/test.js
+++ b/test.js
@@ -47,7 +47,7 @@ test('.add() - concurrency: 5', async t => {
 	const queue = new PQueue({concurrency});
 	let running = 0;
 
-	const input = Array(100).fill(0).map(() => queue.add(async () => {
+	const input = new Array(100).fill(0).map(() => queue.add(async () => {
 		running++;
 		t.true(running <= concurrency);
 		t.true(queue.pending <= concurrency);

--- a/test.js
+++ b/test.js
@@ -166,10 +166,12 @@ test('autoStart: false', t => {
 	queue.add(() => delay(20000));
 	t.is(queue.size, 4);
 	t.is(queue.pending, 0);
+	t.is(queue.isPaused, true);
 
 	queue.start();
 	t.is(queue.size, 2);
 	t.is(queue.pending, 2);
+	t.is(queue.isPaused, false);
 
 	queue.clear();
 	t.is(queue.size, 0);
@@ -186,19 +188,23 @@ test('.pause()', t => {
 	queue.add(() => delay(20000));
 	t.is(queue.size, 5);
 	t.is(queue.pending, 0);
+	t.is(queue.isPaused, true);
 
 	queue.start();
 	t.is(queue.size, 3);
 	t.is(queue.pending, 2);
+	t.is(queue.isPaused, false);
 
 	queue.add(() => delay(20000));
 	queue.pause();
 	t.is(queue.size, 4);
 	t.is(queue.pending, 2);
+	t.is(queue.isPaused, true);
 
 	queue.start();
 	t.is(queue.size, 4);
 	t.is(queue.pending, 2);
+	t.is(queue.isPaused, false);
 
 	queue.clear();
 	t.is(queue.size, 0);

--- a/test.js
+++ b/test.js
@@ -147,12 +147,12 @@ test('enforce number in options.concurrency', t => {
 	}, TypeError);
 	t.notThrows(() => {
 		new PQueue({concurrency: 1});
-	}, TypeError);
+	});
 	t.notThrows(() => {
 		new PQueue({concurrency: 10});
-	}, TypeError);
+	});
 	t.notThrows(() => {
 		new PQueue({concurrency: Infinity});
-	}, TypeError);
+	});
 	/* eslint-enable no-new */
 });


### PR DESCRIPTION
There are cases where some sync operation should be queued after an async op.
Normally you'd do:
```js
return asyncOp.then(() => syncOp());
```
but this doesn't fit every case; `syncOp()` might belong to a separate view.

Wrapping the queue task added, in a resolver solves this.
`Promise.resolve(fn())` —» `fn` can either return a promise or a value. 
