### PR TITLE
Empty recursive stack when resolving onIdle and onEmpty

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -42,7 +42,7 @@ suite
 	.on('complete', function () {
 		console.log('Fastest is ' + this.filter('fastest').map('name'));
 	})
-.run({
-	defer: true,
-	async: true
-});
+	.run({
+		defer: true,
+		async: true
+	});

--- a/index.js
+++ b/index.js
@@ -144,6 +144,8 @@ class PQueue {
 			const existingResolve = this._resolveEmpty;
 			this._resolveEmpty = () => {
 				existingResolve();
+				// Empty the stack trace
+				this._resolveEmpty = () => {};
 				resolve();
 			};
 		});
@@ -159,6 +161,8 @@ class PQueue {
 			const existingResolve = this._resolveIdle;
 			this._resolveIdle = () => {
 				existingResolve();
+				// Empty the stack trace
+				this._resolveIdle = () => {};
 				resolve();
 			};
 		});

--- a/test.js
+++ b/test.js
@@ -47,7 +47,7 @@ test('.add() - concurrency: 5', async t => {
 	const queue = new PQueue({concurrency});
 	let running = 0;
 
-	const input = Array(100).fill(0).map(() => queue.add(async () => {
+	const input = new Array(100).fill(0).map(() => queue.add(async () => {
 		running++;
 		t.true(running <= concurrency);
 		t.true(queue.pending <= concurrency);


### PR DESCRIPTION
Suppose I have a script that makes 10 asynchronous calls and pauses until the queue is idle, using `queue.onIdle()`, before making 10 more calls, pausing using `onIdle`, etc...

Each time `onIdle` is called, the queue's `_resolveIdle` is nested one more time, deepening the stack trace by 1. https://github.com/sindresorhus/p-queue/blob/6f8bb90b8713670ba8dc108928a837e8b6bc0701/index.js#L159-L163

 If the script runs long enough, we run into the following error:

```js
  throw err;
  ^
RangeError: Maximum call stack size exceeded
    at _resolveIdle (/usr/local/src/cardiogram-processor/node_modules/p-queue/index.js:161:5)
    at _resolveIdle (/usr/local/src/cardiogram-processor/node_modules/p-queue/index.js:161:5)
    at _resolveIdle (/usr/local/src/cardiogram-processor/node_modules/p-queue/index.js:161:5)
    at _resolveIdle (/usr/local/src/cardiogram-processor/node_modules/p-queue/index.js:161:5)
...
```

This is fixed by resetting `this._resolveIdle` each time `onIdle` resolves. This is also true for `onEmpty`.

This PR also fixes some style issues that made the tests fail locally.

cc @sindresorhus 