### PR TITLE
Reject on sync function error

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,16 +93,21 @@ class PQueue {
 			const run = () => {
 				this._pendingCount++;
 
-				Promise.resolve((async () => fn())()).then(
-					val => {
-						resolve(val);
-						this._next();
-					},
-					err => {
-						reject(err);
-						this._next();
-					}
-				);
+				try {
+					Promise.resolve(fn()).then(
+						val => {
+							resolve(val);
+							this._next();
+						},
+						err => {
+							reject(err);
+							this._next();
+						}
+					);
+				} catch (err) {
+					reject(err);
+					this._next();
+				}
 			};
 
 			if (!this._isPaused && this._pendingCount < this._concurrency) {

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class PQueue {
 			const run = () => {
 				this._pendingCount++;
 
-				Promise.resolve(fn()).then(
+				Promise.resolve((async () => fn())()).then(
 					val => {
 						resolve(val);
 						this._next();


### PR DESCRIPTION
Fixes #32 

Because we accept synchronous functions, they may throw an error. So `p-queue` crashes because there's nothing to handle that error.