### PR TITLE
Fix `.onEmpty()` not always resolving when size is zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,9 +75,11 @@ class PQueue {
 	_next() {
 		this._pendingCount--;
 
-		if (!this._isPaused && this.queue.size > 0) {
-			this.queue.dequeue()();
-		} else if (this.queue.size <= 0) {
+		if (this.queue.size > 0) {
+			if (!this._isPaused) {
+				this.queue.dequeue()();
+			}
+		} else {
 			this._resolveEmpty();
 			this._resolveEmpty = () => {};
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ class PQueue {
 
 		if (!this._isPaused && this.queue.size > 0) {
 			this.queue.dequeue()();
-		} else {
+		} else if (this.queue.size <= 0) {
 			this._resolveEmpty();
 			this._resolveEmpty = () => {};
 

--- a/test.js
+++ b/test.js
@@ -237,7 +237,7 @@ test('.addAll() sync/async mixed tasks', async t => {
 	t.deepEqual(await p, ['sync 1', undefined, 'sync 2', fixture]);
 });
 
-test('should resolve empty when size is zeor', async t => {
+test('should resolve empty when size is zero', async t => {
 	const queue = new PQueue({concurrency: 1, autoStart: false});
 
 	// It should take 1 seconds to resolve all tasks

--- a/test.js
+++ b/test.js
@@ -236,3 +236,28 @@ test('.addAll() sync/async mixed tasks', async t => {
 	t.is(queue.pending, 4);
 	t.deepEqual(await p, ['sync 1', undefined, 'sync 2', fixture]);
 });
+
+test('should resolve empty when size is zeor', async t => {
+	const queue = new PQueue({concurrency: 1, autoStart: false});
+
+	// It should take 1 seconds to resolve all tasks
+	for (let index = 0; index < 100; index++) {
+    queue.add(() => delay(10));
+	}
+
+  queue.onEmpty().then(() => {
+    t.is(queue.size, 0);
+  });
+
+  queue.start();
+
+	// Pause at 0.5 second
+  setTimeout(async () => {
+    queue.pause();
+    await delay(10);
+    queue.start();
+  }, 500);
+
+  await queue.onIdle();
+});
+


### PR DESCRIPTION
The previous condition is not sufficient to call `_resolveEmpty `.