### PR TITLE
Minor Fix: Support Promises in add(fn, options)

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,17 +196,30 @@ class PQueue {
 				this._pendingCount++;
 				this._intervalCount++;
 
-				try {
-					Promise.resolve(fn()).then(
-						val => {
-							resolve(val);
-							this._next();
-						},
-						err => {
-							reject(err);
-							this._next();
-						}
-					);
+				try  {
+					if ( fn instanceof Promise ) {
+						fn.then(
+							val => {
+								resolve(val);
+								this._next();
+							},
+							err => {
+								reject(err);
+								this._next();
+							}
+						);	
+					} else {
+						Promise.resolve(fn()).then(
+							val => {
+								resolve(val);
+								this._next();
+							},
+							err => {
+								reject(err);
+								this._next();
+							}
+						);	
+					}
 				} catch (err) {
 					reject(err);
 					this._next();


### PR DESCRIPTION
Added a minor `instanceof` check to `add(fn, options)` function in index.js. If `fn` is a Promise, it will be evaluated as a promise instead of a function.