### PR TITLE
Use global isFinite instead of Number.isFinite

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class PQueue {
 			throw new TypeError(`Expected \`intervalCap\` to be a number from 1 and up, got \`${options.intervalCap}\` (${typeof options.intervalCap})`);
 		}
 
-		if (!(typeof options.interval === 'number' && Number.isFinite(options.interval) && options.interval >= 0)) {
+		if (!(typeof options.interval === 'number' && isFinite(options.interval) && options.interval >= 0)) {
 			throw new TypeError(`Expected \`interval\` to be a finite number >= 0, got \`${options.interval}\` (${typeof options.interval})`);
 		}
 


### PR DESCRIPTION
Since the value has already been identified as a number, there is no change to the behavior of the code.

This makes it so that the library is able to be used in ES5 environments (after transpilation).

I know you don't have any interest in maintaining support for non-node environments @sindresorhus, but I'm hoping that there is no difference in behavior or code complexity here that you will be okay with merging so that I don't have to maintain a downstream fork.

I will take full responsibility for any further ES5 issues, I don't expect you to put any effort into supporting non-node environments going forward.