### PR TITLE
Add `active` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ class PQueue extends EventEmitter {
 
 	_next() {
 		this._pendingCount--;
-		this.emit('active');
 		this._tryToStartAnother();
 	}
 
@@ -164,6 +163,7 @@ class PQueue extends EventEmitter {
 		if (!this._isPaused) {
 			const canInitializeInterval = !this._intervalPaused();
 			if (this._doesIntervalAllowAnother && this._doesConcurrentAllowAnother) {
+				this.emit('active');
 				this.queue.dequeue()();
 				if (canInitializeInterval) {
 					this._initializeIntervalIfNeeded();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const events = require('events');
+
 // Port of lower_bound from http://en.cppreference.com/w/cpp/algorithm/lower_bound
 // Used to compute insertion index to keep queue sorted after insertion
 function lowerBound(array, value, comp) {
@@ -51,8 +53,10 @@ class PriorityQueue {
 	}
 }
 
-class PQueue {
+class PQueue extends events {
 	constructor(options) {
+		super();
+
 		options = Object.assign({
 			carryoverConcurrencyCount: false,
 			intervalCap: Infinity,
@@ -101,6 +105,7 @@ class PQueue {
 	}
 
 	_next() {
+		this.emit('onNext');
 		this._pendingCount--;
 		this._tryToStartAnother();
 	}

--- a/index.js
+++ b/index.js
@@ -105,8 +105,8 @@ class PQueue extends events {
 	}
 
 	_next() {
-		this.emit('onNext');
 		this._pendingCount--;
+		this.emit('onNext');
 		this._tryToStartAnother();
 	}
 

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ class PQueue extends EventEmitter {
 
 	_next() {
 		this._pendingCount--;
-		this.emit('next');
+		this.emit('active');
 		this._tryToStartAnother();
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const events = require('events');
+const EventEmitter = require('events');
 
 // Port of lower_bound from http://en.cppreference.com/w/cpp/algorithm/lower_bound
 // Used to compute insertion index to keep queue sorted after insertion
@@ -53,7 +53,7 @@ class PriorityQueue {
 	}
 }
 
-class PQueue extends events {
+class PQueue extends EventEmitter {
 	constructor(options) {
 		super();
 
@@ -106,7 +106,7 @@ class PQueue extends events {
 
 	_next() {
 		this._pendingCount--;
-		this.emit('onNext');
+		this.emit('next');
 		this._tryToStartAnother();
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ getUnicornTask().then(task => queue.add(task)).then(() => {
 
 ### PQueue([options])
 
-Returns a new `queue` instance.  Each instance is a subclass of a Node [EventEmitter](https://nodejs.org/api/events.html) and inherits its API. 
+Returns a new `queue` instance, which is an [`EventEmitter`](https://nodejs.org/api/events.html) subclass. 
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -155,18 +155,20 @@ Number of pending promises.
 
 Whether the queue is currently paused.
 
+
 ## Events
 
 #### active
+
 Emitted as each item is processed in the queue for the purpose of tracking progress.
 
 ```js
 const delay = require('delay');
 const PQueue = require('p-queue');
+
 const queue = new PQueue({concurrency: 2});
 
 let count = 0;
-
 queue.on('active', () => {
 	console.log(`Working on item #${++count}.  Size: ${queue.size}  Pending: ${queue.pending}`);
 });
@@ -177,6 +179,7 @@ queue.add(() => Promise.resolve());
 queue.add(() => Promise.resolve());
 queue.add(() => delay(500));
 ```
+
 
 ## Advanced example
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ getUnicornTask().then(task => queue.add(task)).then(() => {
 
 ### PQueue([options])
 
-Returns a new `queue` instance.
+Returns a new `queue` instance.  Each instance is a subclass of a Node [EventEmitter](https://nodejs.org/api/events.html) and inherits its API. 
 
 #### options
 
@@ -157,8 +157,26 @@ Whether the queue is currently paused.
 
 ## Events
 
-#### next
+#### active
 Emitted as each item is processed in the queue for the purpose of tracking progress.
+
+```js
+const delay = require('delay');
+const PQueue = require('p-queue');
+const queue = new PQueue({concurrency: 2});
+
+let count = 0;
+
+queue.on('active', () => {
+	console.log(`Working on item #${++count}.  Size: ${queue.size}  Pending: ${queue.pending}`);
+});
+
+queue.add(() => Promise.resolve());
+queue.add(() => delay(2000));
+queue.add(() => Promise.resolve());
+queue.add(() => Promise.resolve());
+queue.add(() => delay(500));
+```
 
 ## Advanced example
 

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,11 @@ Number of pending promises.
 
 Whether the queue is currently paused.
 
+## Events
+
+#### next
+Emitted as each item is processed in the queue for the purpose of tracking progress.
+
 ## Advanced example
 
 A more advanced example to help you understand the flow.

--- a/test.js
+++ b/test.js
@@ -411,10 +411,12 @@ test('should be an event emitter', t => {
 
 test('should emit active event per item', async t => {
 	const items = [0, 1, 2, 3, 4];
-	let eventCount = 0;
 	const queue = new PQueue();
 
-	queue.on('active', () => eventCount++);
+	let eventCount = 0;
+	queue.on('active', () => {
+		eventCount++;
+	});
 
 	for (const item of items) {
 		queue.add(() => item);

--- a/test.js
+++ b/test.js
@@ -402,3 +402,23 @@ test('pause should work when throttled', async t => {
 	delay(2200).then(() => t.deepEqual(result, secondV));
 	await delay(2500);
 });
+
+test('should be an event emitter', t => {
+	const events = require('events');
+	const queue = new PQueue();
+	t.true(queue instanceof events);
+});
+
+test('should emit onNext event per item', async t => {
+	const items = [0, 1, 2, 3, 4];
+	let onNextCount = 0;
+	const queue = new PQueue();
+
+	queue.on('onNext', () => onNextCount++);
+
+	items.forEach(item => queue.add(() => item));
+
+	await queue.onIdle();
+
+	t.is(onNextCount, items.length);
+});

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import EventEmitter from 'events';
 import test from 'ava';
 import delay from 'delay';
 import inRange from 'in-range';
@@ -404,21 +405,20 @@ test('pause should work when throttled', async t => {
 });
 
 test('should be an event emitter', t => {
-	const events = require('events');
 	const queue = new PQueue();
-	t.true(queue instanceof events);
+	t.true(queue instanceof EventEmitter);
 });
 
-test('should emit onNext event per item', async t => {
+test('should emit next event per item', async t => {
 	const items = [0, 1, 2, 3, 4];
-	let onNextCount = 0;
+	let eventCount = 0;
 	const queue = new PQueue();
 
-	queue.on('onNext', () => onNextCount++);
+	queue.on('next', () => eventCount++);
 
 	items.forEach(item => queue.add(() => item));
 
 	await queue.onIdle();
 
-	t.is(onNextCount, items.length);
+	t.is(eventCount, items.length);
 });

--- a/test.js
+++ b/test.js
@@ -409,14 +409,16 @@ test('should be an event emitter', t => {
 	t.true(queue instanceof EventEmitter);
 });
 
-test('should emit next event per item', async t => {
+test('should emit active event per item', async t => {
 	const items = [0, 1, 2, 3, 4];
 	let eventCount = 0;
 	const queue = new PQueue();
 
-	queue.on('next', () => eventCount++);
+	queue.on('active', () => eventCount++);
 
-	items.forEach(item => queue.add(() => item));
+	for (const item of items) {
+		queue.add(() => item);
+	}
 
 	await queue.onIdle();
 


### PR DESCRIPTION
Similar in spirit to a proprosal in #41.  This doesn't necessitate the use case mentioned in that issue, but it would provide a tool which could be used for that purpose.  My motivation for this would be to have a hook into the processing without requiring an external interval to poll a queue instance.