### PR TITLE
Use `eventemitter3` module instead of Node.js EventEmitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const EventEmitter = require('events');
+const EventEmitter = require('eventemitter3');
 
 // Port of lower_bound from http://en.cppreference.com/w/cpp/algorithm/lower_bound
 // Used to compute insertion index to keep queue sorted after insertion

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
 		"time-span": "^2.0.0",
 		"tsd-check": "^0.3.0",
 		"xo": "^0.24.0"
+	},
+	"dependencies": {
+		"eventemitter3": "^3.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
 		"promises",
 		"bluebird"
 	],
+	"dependencies": {
+		"eventemitter3": "^3.1.0"
+	},
 	"devDependencies": {
 		"@types/node": "^11.9.6",
 		"ava": "^1.2.1",
@@ -49,8 +52,5 @@
 		"time-span": "^2.0.0",
 		"tsd-check": "^0.3.0",
 		"xo": "^0.24.0"
-	},
-	"dependencies": {
-		"eventemitter3": "^3.1.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ getUnicornTask().then(task => queue.add(task)).then(() => {
 
 ### PQueue([options])
 
-Returns a new `queue` instance, which is an [`EventEmitter`](https://nodejs.org/api/events.html) subclass. 
+Returns a new `queue` instance, which is an [`EventEmitter3`](https://github.com/primus/eventemitter3) subclass.
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'eventemitter3';
 import test from 'ava';
 import delay from 'delay';
 import inRange from 'in-range';


### PR DESCRIPTION
As outlined in https://github.com/sindresorhus/p-queue/issues/55#issuecomment-467331355 - this replaces the `events` dependency with `eventemitter3`, making this module work without issues in browsers and react native environments.

Fixes #55 