### PR TITLE
Refactor TypeScript definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,148 +1,150 @@
 /// <reference types="node"/>
 import {EventEmitter} from 'events';
 
-export interface QueueAddOptions {
-	[key: string]: unknown;
+declare namespace PQueue {
+	interface QueueAddOptions {
+		[key: string]: unknown;
+	}
+
+	interface QueueClass<EnqueueOptionsType extends QueueAddOptions> {
+		size: number;
+
+		enqueue(run: () => void, options?: EnqueueOptionsType): void;
+
+		dequeue(): (() => void) | undefined;
+	}
+
+	interface QueueClassConstructor<EnqueueOptionsType extends QueueAddOptions> {
+		new (): QueueClass<EnqueueOptionsType>;
+	}
+
+	interface Options<EnqueueOptionsType extends QueueAddOptions> {
+		/**
+		Concurrency limit. Minimum: `1`.
+
+		@default Infinity
+		*/
+		concurrency?: number;
+
+		/**
+		Whether queue tasks within concurrency limit, are auto-executed as soon as they're added.
+
+		@default true
+		*/
+		autoStart?: boolean;
+
+		/**
+		Class with a `enqueue` and `dequeue` method, and a `size` getter. See the [Custom QueueClass](https://github.com/sindresorhus/p-queue#custom-queueclass) section.
+		*/
+		queueClass?: QueueClassConstructor<EnqueueOptionsType>;
+
+		/**
+		The max number of runs in the given interval of time. Minimum: `1`.
+
+		@default Infinity
+		*/
+		intervalCap?: number;
+
+		/**
+		The length of time in milliseconds before the interval count resets. Must be finite. Minimum: `0`.
+
+		@default 0
+		*/
+		interval?: number;
+
+		/**
+		Whether the task must finish in the given interval or will be carried over into the next interval count.
+
+		@default false
+		*/
+		carryoverConcurrencyCount?: boolean;
+	}
+
+	interface DefaultAddOptions {
+		/**
+		Priority of operation. Operations with greater priority will be scheduled first.
+
+		@default 0
+		*/
+		priority?: number;
+	}
+
+	type Task<TaskResultType> =
+		| (() => PromiseLike<TaskResultType>)
+		| (() => TaskResultType);
 }
-
-export interface QueueClass<EnqueueOptionsType extends QueueAddOptions> {
-	size: number;
-
-	enqueue(run: () => void, options?: EnqueueOptionsType): void;
-
-	dequeue(): (() => void) | undefined;
-}
-
-export interface QueueClassConstructor<EnqueueOptionsType extends QueueAddOptions> {
-	new(): QueueClass<EnqueueOptionsType>;
-}
-
-export interface Options<EnqueueOptionsType extends QueueAddOptions> {
-	/**
-	 * Concurrency limit. Minimum: `1`.
-	 *
-	 * @default Infinity
-	 */
-	concurrency?: number;
-
-	/**
-	 * Whether queue tasks within concurrency limit, are auto-executed as soon as they're added.
-	 *
-	 * @default true
-	 */
-	autoStart?: boolean;
-
-	/**
-	 * Class with a `enqueue` and `dequeue` method, and a `size` getter. See the [Custom QueueClass](https://github.com/sindresorhus/p-queue#custom-queueclass) section.
-	 */
-	queueClass?: QueueClassConstructor<EnqueueOptionsType>;
-
-	/**
-	 * The max number of runs in the given interval of time. Minimum: `1`.
-	 *
-	 * @default Infinity
-	 */
-	intervalCap?: number;
-
-	/**
-	 * The length of time in milliseconds before the interval count resets. Must be finite. Minimum: `0`.
-	 *
-	 * @default 0
-	 */
-	interval?: number;
-
-	/**
-	 * Whether the task must finish in the given interval or will be carried over into the next interval count.
-	 *
-	 * @default false
-	 */
-	carryoverConcurrencyCount?: boolean;
-}
-
-export interface DefaultAddOptions {
-	/**
-	 * Priority of operation. Operations with greater priority will be scheduled first.
-	 *
-	 * @default 0
-	 */
-	priority?: number;
-}
-
-export type Task<TaskResultType> =
-	| (() => PromiseLike<TaskResultType>)
-	| (() => TaskResultType);
 
 /**
- * Promise queue with concurrency control.
- */
-export default class PQueue<
-	EnqueueOptionsType extends QueueAddOptions = DefaultAddOptions
+Promise queue with concurrency control.
+*/
+declare class PQueue<
+	EnqueueOptionsType extends PQueue.QueueAddOptions = PQueue.DefaultAddOptions
 > extends EventEmitter {
 	/**
-	 * Size of the queue.
-	 */
+	Size of the queue.
+	*/
 	readonly size: number;
 
 	/**
-	 * Number of pending promises.
-	 */
+	Number of pending promises.
+	*/
 	readonly pending: number;
 
 	/**
-	 * Whether the queue is currently paused.
-	 */
+	Whether the queue is currently paused.
+	*/
 	readonly isPaused: boolean;
 
-	constructor(options?: Options<EnqueueOptionsType>);
+	constructor(options?: PQueue.Options<EnqueueOptionsType>);
 
 	/**
-	 * Adds a sync or async task to the queue. Always returns a promise.
-	 *
-	 * @param fn - Promise-returning/async function.
-	 */
+	Adds a sync or async task to the queue. Always returns a promise.
+
+	@param fn - Promise-returning/async function.
+	*/
 	add<TaskResultType>(
-		fn: Task<TaskResultType>,
+		fn: PQueue.Task<TaskResultType>,
 		options?: EnqueueOptionsType
 	): Promise<TaskResultType>;
 
 	/**
-	 * Same as `.add()`, but accepts an array of sync or async functions.
-	 *
-	 * @param fn - Array of Promise-returning/async functions.
-	 * @returns A promise that resolves when all functions are resolved.
-	 */
+	Same as `.add()`, but accepts an array of sync or async functions.
+
+	@param fn - Array of Promise-returning/async functions.
+	@returns A promise that resolves when all functions are resolved.
+	*/
 	addAll<TaskResultsType>(
-		fns: Task<TaskResultsType>[],
+		fns: PQueue.Task<TaskResultsType>[],
 		options?: EnqueueOptionsType
 	): Promise<TaskResultsType[]>;
 
 	/**
-	 * Can be called multiple times. Useful if you for example add additional items at a later time.
-	 *
-	 * @returns A promise that settles when the queue becomes empty.
-	 */
+	Can be called multiple times. Useful if you for example add additional items at a later time.
+
+	@returns A promise that settles when the queue becomes empty.
+	*/
 	onEmpty(): Promise<void>;
 
 	/**
-	 * The difference with `.onEmpty` is that `.onIdle` guarantees that all work from the queue has finished. `.onEmpty` merely signals that the queue is empty, but it could mean that some promises haven't completed yet.
-	 *
-	 * @returns A promise that settles when the queue becomes empty, and all promises have completed; `queue.size === 0 && queue.pending === 0`.
-	 */
+	The difference with `.onEmpty` is that `.onIdle` guarantees that all work from the queue has finished. `.onEmpty` merely signals that the queue is empty, but it could mean that some promises haven't completed yet.
+
+	@returns A promise that settles when the queue becomes empty, and all promises have completed; `queue.size === 0 && queue.pending === 0`.
+	*/
 	onIdle(): Promise<void>;
 
 	/**
-	 * Start (or resume) executing enqueued tasks within concurrency limit. No need to call this if queue is not paused (via `options.autoStart = false` or by `.pause()` method.)
-	 */
+	Start (or resume) executing enqueued tasks within concurrency limit. No need to call this if queue is not paused (via `options.autoStart = false` or by `.pause()` method.)
+	*/
 	start(): void;
 
 	/**
-	 * Clear the queue.
-	 */
+	Clear the queue.
+	*/
 	clear(): void;
 
 	/**
-	 * Put queue execution on hold.
-	 */
+	Put queue execution on hold.
+	*/
 	pause(): void;
 
 	addListener(event: 'active', listener: () => void): this;
@@ -159,3 +161,5 @@ export default class PQueue<
 	eventNames(): 'active'[];
 	listenerCount(type: 'active'): number;
 }
+
+export = PQueue;

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class PriorityQueue {
 	}
 }
 
-class PQueue extends EventEmitter {
+module.exports = class PQueue extends EventEmitter {
 	constructor(options) {
 		super();
 
@@ -285,7 +285,4 @@ class PQueue extends EventEmitter {
 	get isPaused() {
 		return this._isPaused;
 	}
-}
-
-module.exports = PQueue;
-module.exports.default = PQueue;
+};

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,6 @@
-import {expectType} from 'tsd-check';
-import PQueue, {QueueClass} from '.';
+import {expectType} from 'tsd';
+import PQueue = require('.');
+import {QueueClass} from '.';
 
 const queue = new PQueue({concurrency: 1});
 new PQueue({autoStart: false});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && nyc ava && tsd-check",
+		"test": "xo && nyc ava && tsd",
 		"bench": "node bench.js"
 	},
 	"files": [
@@ -41,16 +41,16 @@
 		"eventemitter3": "^3.1.0"
 	},
 	"devDependencies": {
-		"@types/node": "^11.9.6",
-		"ava": "^1.2.1",
-		"benchmark": "^2.1.2",
-		"codecov": "^3.1.0",
+		"@types/node": "^11.13.0",
+		"ava": "^1.4.1",
+		"benchmark": "^2.1.4",
+		"codecov": "^3.3.0",
 		"delay": "^4.1.0",
 		"in-range": "^1.0.0",
-		"nyc": "^13.0.1",
+		"nyc": "^13.3.0",
 		"random-int": "^1.0.0",
 		"time-span": "^2.0.0",
-		"tsd-check": "^0.3.0",
+		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
**Breaking change** for the same reasons as `PCancelable`.