### PR TITLE
Fix TypeScript 3.5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"random-int": "^2.0.0",
 		"time-span": "^3.1.0",
 		"ts-node": "^8.0.3",
-		"typescript": "^3.4.3",
+		"typescript": "~3.5.1",
 		"xo": "^0.24.0"
 	},
 	"ava": {

--- a/source/options.ts
+++ b/source/options.ts
@@ -71,4 +71,6 @@ export interface DefaultAddOptions {
 	@default 0
 	*/
 	readonly priority?: number;
+
+	readonly [key: string]: unknown;
 }

--- a/source/options.ts
+++ b/source/options.ts
@@ -64,13 +64,11 @@ export interface Options<QueueType extends Queue<QueueOptions>, QueueOptions ext
 	throwOnTimeout?: boolean;
 }
 
-export interface DefaultAddOptions {
+export interface DefaultAddOptions extends QueueAddOptions {
 	/**
 	Priority of operation. Operations with greater priority will be scheduled first.
 
 	@default 0
 	*/
 	readonly priority?: number;
-
-	readonly [key: string]: unknown;
 }


### PR DESCRIPTION
This fixes #66.  In our TypeScript npm modules, we're unable to use this library because of the bug in #66.  This PR does a few things:
- Bumps the required TypeScript version to `3.5.1`
- Moves to a `~` range specifier, as the TypeScript compiler makes breaking changes in minor relases
- Loosens the type required for `DefaultAddOptions`.  I'm not super confident with this particular change, so it could use another set of 👀  