### PR TITLE
Add missing package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Promise queue with concurrency control",
 	"license": "MIT",
 	"repository": "sindresorhus/p-queue",
+	"main": "dist/index.js",
 	"engines": {
 		"node": ">=8"
 	},
@@ -16,7 +17,6 @@
 	"files": [
 		"dist"
 	],
-	"main": "dist/index.js",
 	"types": "dist",
 	"keywords": [
 		"promise",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"files": [
 		"dist"
 	],
+	"main": "dist/index.js",
 	"types": "dist",
 	"keywords": [
 		"promise",


### PR DESCRIPTION
Upgrade to 6.0.0 breaks module resolution due to missing index file that was previously at the package root, but now it is included within the `dist` directory. Offending changes introduced by modification of `files` package.json entry: https://github.com/sindresorhus/p-queue/commit/a9d3ad9996d0f6cc91bb63676bf43ef2c764971b
Solved by the inclusion of `main` package.json field which points to the correct entry point inside the `dist` folder.

Error:
```sh
internal/modules/cjs/loader.js:613
    throw err;
    ^

Error: Cannot find module 'p-queue'
Require stack:
- [REDACTED]\index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:610:15)
    at Function.Module._load (internal/modules/cjs/loader.js:526:27)
    at Module.require (internal/modules/cjs/loader.js:666:19)
    at require (internal/modules/cjs/helpers.js:16:16)
    at Object.<anonymous> ([REDACTED])
    at Module._compile (internal/modules/cjs/loader.js:759:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:770:10)
    at Module.load (internal/modules/cjs/loader.js:628:32)
    at Function.Module._load (internal/modules/cjs/loader.js:555:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:824:10)
```

Fixes:
#70 