### PR TITLE
TypeScript - Properly export interfaces

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -350,3 +350,5 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 		return this._timeout;
 	}
 }
+
+export { Queue, QueueAddOptions, DefaultAddOptions, Options };

--- a/source/index.ts
+++ b/source/index.ts
@@ -351,4 +351,4 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 	}
 }
 
-export { Queue, QueueAddOptions, DefaultAddOptions, Options };
+export {Queue, QueueAddOptions, DefaultAddOptions, Options};


### PR DESCRIPTION
With latest v6 changes, in order to define a custom `Queue` class, one will need to do the following

```ts
import { Queue } from 'p-queue/dist/queue';
import { QueueAddOptions } from 'p-queue/dist/options';

class CustomQueue implements Queue<NamedQueueOptions> {}
```

This PR will simplify this to

```ts
import { Queue, QueueAddOption } from 'p-queue';

class CustomQueue implements Queue<NamedQueueOptions> {}
```
