### PR TITLE
TypeScript - Fix import for dependencies with no default export

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,8 +1,9 @@
-import EventEmitter from 'eventemitter3';
 import pTimeout from 'p-timeout';
 import {Queue} from './queue';
 import PriorityQueue from './priority-queue';
 import {QueueAddOptions, DefaultAddOptions, Options} from './options';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import EventEmitter = require('eventemitter3');
 
 type ResolveFunction<T = void> = (value?: T | PromiseLike<T>) => void;
 


### PR DESCRIPTION
Started seeing this error popup

```
node_modules/p-queue/dist/index.d.ts:1:8 - error TS1259: Module '"/node_modules/eventemitter3/index"' can only be default-imported using the 'esModuleInterop' flag

1 import EventEmitter from 'eventemitter3';
         ~~~~~~~~~~~~

  node_modules/eventemitter3/index.d.ts:64:1
    64 export = EventEmitter;
       ~~~~~~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```