### PR TITLE
Correct the documented default for the `throwOnTimeout` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "p-queue",
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"description": "Promise queue with concurrency control",
 	"license": "MIT",
 	"repository": "sindresorhus/p-queue",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"@types/benchmark": "^1.0.31",
 		"@types/node": "^12.0.7",
 		"@typescript-eslint/eslint-plugin": "^1.9.0",
+		"@typescript-eslint/parser": "^1.10.2",
 		"ava": "^2.0.0",
 		"benchmark": "^2.1.4",
 		"codecov": "^3.3.0",

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Per-operation timeout in milliseconds. Operations fulfill once `timeout` elapses
 ##### throwOnTimeout
 
 Type: `boolean`<br>
-Default: `true`
+Default: `false`
 
 Whether or not a timeout is considered an exception.
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -215,11 +215,11 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 				this._intervalCount++;
 
 				try {
-					const operation = this._timeout === undefined ? fn() : pTimeout(
+					const operation = (this._timeout === undefined && (options === undefined || (options !== undefined && options.timeout === undefined))) ? fn() : pTimeout(
 						Promise.resolve(fn()),
-						this._timeout,
+						((options !== undefined && options.timeout !== undefined) ? options.timeout : this._timeout) as number,
 						() => {
-							if (this._throwOnTimeout) {
+							if ((options !== undefined && options.throwOnTimeout !== undefined) ? options.throwOnTimout : this._throwOnTimeout) {
 								reject(timeoutError);
 							}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -208,18 +208,19 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 	/**
 	Adds a sync or async task to the queue. Always returns a promise.
 	*/
-	async add<TaskResultType>(fn: Task<TaskResultType>, options?: EnqueueOptionsType): Promise<TaskResultType> {
+	async add<TaskResultType>(fn: Task<TaskResultType>, addOptions?: EnqueueOptionsType): Promise<TaskResultType> {
+		const options = (addOptions || {}) as EnqueueOptionsType;
 		return new Promise<TaskResultType>((resolve, reject) => {
 			const run = async (): Promise<void> => {
 				this._pendingCount++;
 				this._intervalCount++;
 
 				try {
-					const operation = (this._timeout === undefined && (options === undefined || (options !== undefined && options.timeout === undefined))) ? fn() : pTimeout(
+					const operation = (this._timeout === undefined && (options.timeout === undefined)) ? fn() : pTimeout(
 						Promise.resolve(fn()),
-						((options !== undefined && options.timeout !== undefined) ? options.timeout : this._timeout) as number,
+						(options.timeout === undefined ? this._timeout : options.timeout) as number,
 						() => {
-							if ((options !== undefined && options.throwOnTimeout !== undefined) ? options.throwOnTimout : this._throwOnTimeout) {
+							if (options.throwOnTimeout === undefined ? this._throwOnTimeout : options.throwOnTimout) {
 								reject(timeoutError);
 							}
 

--- a/source/options.ts
+++ b/source/options.ts
@@ -59,7 +59,7 @@ export interface Options<QueueType extends Queue<QueueOptions>, QueueOptions ext
 	/**
 	Whether or not a timeout is considered an exception.
 
-	@default true
+	@default false
 	*/
 	throwOnTimeout?: boolean;
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -735,3 +735,29 @@ test('should emit active event per item', async t => {
 
 	t.is(eventCount, items.length);
 });
+
+test('should verify timeout overrides passed to add', async t => {
+	const queue = new PQueue({timeout: 200, throwOnTimeout: true});
+
+	t.throwsAsync(queue.add(async () => {
+		await delay(400);
+	}));
+
+	t.notThrowsAsync(queue.add(async () => {
+		await delay(400);
+	}, {throwOnTimeout: false}));
+
+	t.notThrowsAsync(queue.add(async () => {
+		await delay(400);
+	}, {timeout: 600}));
+
+	t.notThrowsAsync(queue.add(async () => {
+		await delay(100);
+	}));
+
+	t.throwsAsync(queue.add(async () => {
+		await delay(100);
+	}, {timeout: 50}));
+
+	await queue.onIdle();
+});


### PR DESCRIPTION
See questions in #74 - this is one possible option with a test and documentation fix for the throwOnTimeout default.

I'm not well-versed in typescript, but it seems like there's probably a better means for optional parameter lookups than this?

Fixes #74