### PR TITLE
Fix typo in options logic when adding a task

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -236,7 +236,7 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 						Promise.resolve(fn()),
 						(options.timeout === undefined ? this._timeout : options.timeout) as number,
 						() => {
-							if (options.throwOnTimeout === undefined ? this._throwOnTimeout : options.throwOnTimout) {
+							if (options.throwOnTimeout === undefined ? this._throwOnTimeout : options.throwOnTimeout) {
 								reject(timeoutError);
 							}
 


### PR DESCRIPTION
This fixes an issue where `throwOnTimeout` would not be respected due to a typo (`throwOnTimout` vs `throwOnTimeout`).

This wasn't picked up by typings as the typings are incredibly loose, where any property of an object is a valid property. I'd suggest improving these typings (might do this in a future PR).
