### PR TITLE
Don't publish source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"prepublishOnly": "npm run build"
 	},
 	"files": [
-		"dist"
+		"dist/*.d.ts",
+		"dist/*.js"
 	],
 	"types": "dist",
 	"keywords": [


### PR DESCRIPTION
A small fix to get rid of some warnings shown when bundling for a frontend application.

The source maps link to `source/*` files that are not published, yielding warnings á la `Could not load source file "../source/index.ts" in source map of "../node_modules/p-queue/dist/index.js"` in parcel bundler.