### PR TITLE
Fix importing `TimeoutError`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,5 +1,5 @@
 import EventEmitter = require('eventemitter3');
-import pTimeout from 'p-timeout';
+import {default as pTimeout, TimeoutError} from 'p-timeout';
 import {Queue} from './queue';
 import PriorityQueue from './priority-queue';
 import {QueueAddOptions, DefaultAddOptions, Options} from './options';
@@ -12,7 +12,7 @@ type Task<TaskResultType> =
 
 const empty = (): void => {};
 
-const timeoutError = new pTimeout.TimeoutError();
+const timeoutError = new TimeoutError();
 
 /**
 Promise queue with concurrency control.

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,7 +82,7 @@ test('.add() - update concurrency', async t => {
 		running--;
 
 		if (index % 30 === 0) {
-                        // eslint-disable-next-line require-atomic-updates	
+                      // eslint-disable-next-line require-atomic-updates	
 			queue.concurrency = --concurrency;
 			t.is(queue.concurrency, concurrency);
 		}

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,7 +82,7 @@ test('.add() - update concurrency', async t => {
 		running--;
 
 		if (index % 30 === 0) {
-      // eslint-disable-next-line require-atomic-updates
+			// eslint-disable-next-line require-atomic-updates
 			queue.concurrency = --concurrency;
 			t.is(queue.concurrency, concurrency);
 		}

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,7 +82,7 @@ test('.add() - update concurrency', async t => {
 		running--;
 
 		if (index % 30 === 0) {
-                      // eslint-disable-next-line require-atomic-updates
+      // eslint-disable-next-line require-atomic-updates
 			queue.concurrency = --concurrency;
 			t.is(queue.concurrency, concurrency);
 		}

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,7 +82,6 @@ test('.add() - update concurrency', async t => {
 		running--;
 
 		if (index % 30 === 0) {
-			// eslint-disable-next-line require-atomic-updates
 			queue.concurrency = --concurrency;
 			t.is(queue.concurrency, concurrency);
 		}

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,7 +82,7 @@ test('.add() - update concurrency', async t => {
 		running--;
 
 		if (index % 30 === 0) {
-                      // eslint-disable-next-line require-atomic-updates	
+                      // eslint-disable-next-line require-atomic-updates
 			queue.concurrency = --concurrency;
 			t.is(queue.concurrency, concurrency);
 		}

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,6 +82,7 @@ test('.add() - update concurrency', async t => {
 		running--;
 
 		if (index % 30 === 0) {
+                        // eslint-disable-next-line require-atomic-updates	
 			queue.concurrency = --concurrency;
 			t.is(queue.concurrency, concurrency);
 		}


### PR DESCRIPTION
## The Problem
The built TS file attempts to access `ptimeout_1.default.TimeoutError()` which under some conditions (IE: inside of Electron) returns undefined.

## Changes
- Importing `pTimeout` and `TimeoutError` separately

