### PR TITLE
Add `.sizeBy()` method to find queue size by priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"random-int": "^2.0.0",
 		"time-span": "^3.1.0",
 		"ts-node": "^8.3.0",
-		"typescript": "^3.7.2",
+		"typescript": "3.7.2",
 		"xo": "^0.25.3"
 	},
 	"ava": {

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,22 @@ Clear the queue.
 
 Size of the queue.
 
+
+#### .sizeBy(options)
+
+Size of the queue, filtered by the provided options.
+
+```js
+const queue = new PQueue();
+queue.add(async () => '🦄', {priority: 1});
+queue.add(async () => '🦄', {priority: 0});
+queue.add(async () => '🦄', {priority: 1});
+console.log(queue.sizeBy({priority: 1}));
+//=> 2
+console.log(queue.sizeBy({priority: 0}));
+//=> 1
+```
+
 #### .pending
 
 Number of pending promises.
@@ -292,6 +308,9 @@ class QueueClass {
 	}
 	get size() {
 		return this._queue.length;
+	}
+	filter(options) {
+		return this._queue;
 	}
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,8 @@ Size of the queue.
 
 Size of the queue, filtered by the given options.
 
+For example, this can be used to find the number of items remaining in the queue with a specific priority level.
+
 ```js
 const queue = new PQueue();
 

--- a/readme.md
+++ b/readme.md
@@ -173,11 +173,14 @@ Size of the queue, filtered by the provided options.
 
 ```js
 const queue = new PQueue();
+
 queue.add(async () => '🦄', {priority: 1});
 queue.add(async () => '🦄', {priority: 0});
 queue.add(async () => '🦄', {priority: 1});
+
 console.log(queue.sizeBy({priority: 1}));
 //=> 2
+
 console.log(queue.sizeBy({priority: 0}));
 //=> 1
 ```
@@ -300,15 +303,19 @@ class QueueClass {
 	constructor() {
 		this._queue = [];
 	}
+
 	enqueue(run, options) {
 		this._queue.push(run);
 	}
+
 	dequeue() {
 		return this._queue.shift();
 	}
+
 	get size() {
 		return this._queue.length;
 	}
+
 	filter(options) {
 		return this._queue;
 	}

--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ Size of the queue.
 
 #### .sizeBy(options)
 
-Size of the queue, filtered by the provided options.
+Size of the queue, filtered by the given options.
 
 ```js
 const queue = new PQueue();

--- a/source/index.ts
+++ b/source/index.ts
@@ -346,6 +346,7 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 
 	/**
 	Size of the queue filtered by options.
+	For example, this can be used to find the number of items remaining in the queue with a specific priority level.
 	*/
 	sizeBy(options: Partial<EnqueueOptionsType>): number {
 		return this._queue.filter(options).length;

--- a/source/index.ts
+++ b/source/index.ts
@@ -348,7 +348,7 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 	Size of the queue filtered by options.
 	*/
 	sizeBy(options: Partial<EnqueueOptionsType>): number {
-		return this._queue.sizeBy(options);
+		return this._queue.filter(options).length;
 	}
 
 	/**

--- a/source/index.ts
+++ b/source/index.ts
@@ -345,7 +345,8 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
-	Size of the queue filtered by options.
+	Size of the queue, filtered by the given options.
+
 	For example, this can be used to find the number of items remaining in the queue with a specific priority level.
 	*/
 	sizeBy(options: Partial<EnqueueOptionsType>): number {

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,6 +1,6 @@
 import EventEmitter = require('eventemitter3');
 import {default as pTimeout, TimeoutError} from 'p-timeout';
-import {Queue} from './queue';
+import {Queue, RunFunction} from './queue';
 import PriorityQueue from './priority-queue';
 import {QueueAddOptions, DefaultAddOptions, Options} from './options';
 
@@ -17,7 +17,7 @@ const timeoutError = new TimeoutError();
 /**
 Promise queue with concurrency control.
 */
-export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = PriorityQueue, EnqueueOptionsType extends QueueAddOptions = DefaultAddOptions> extends EventEmitter<'active'> {
+export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsType> = PriorityQueue, EnqueueOptionsType extends QueueAddOptions = DefaultAddOptions> extends EventEmitter<'active'> {
 	private readonly _carryoverConcurrencyCount: boolean;
 
 	private readonly _isIntervalIgnored: boolean;

--- a/source/index.ts
+++ b/source/index.ts
@@ -345,6 +345,13 @@ export default class PQueue<QueueType extends Queue<EnqueueOptionsType> = Priori
 	}
 
 	/**
+	Size of the queue filtered by options.
+	*/
+	sizeBy(options: Partial<EnqueueOptionsType>): number {
+		return this._queue.sizeBy(options);
+	}
+
+	/**
 	Number of pending promises.
 	*/
 	get pending(): number {

--- a/source/options.ts
+++ b/source/options.ts
@@ -1,10 +1,10 @@
-import {Queue} from './queue';
+import {Queue, RunFunction} from './queue';
 
 export interface QueueAddOptions {
 	readonly [key: string]: unknown;
 }
 
-export interface Options<QueueType extends Queue<QueueOptions>, QueueOptions extends QueueAddOptions> {
+export interface Options<QueueType extends Queue<RunFunction, QueueOptions>, QueueOptions extends QueueAddOptions> {
 	/**
 	Concurrency limit.
 

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -34,8 +34,8 @@ export default class PriorityQueue implements Queue<PriorityQueueOptions> {
 		return item && item.run;
 	}
 
-	sizeBy(options: Partial<PriorityQueueOptions>): number {
-		return this._queue.filter(element => element.priority === options.priority).length;
+	filter(options: Partial<PriorityQueueOptions>): Array<{}> {
+		return this._queue.filter(element => element.priority === options.priority);
 	}
 
 	get size(): number {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -6,7 +6,7 @@ export interface PriorityQueueOptions extends QueueAddOptions {
 	priority?: number;
 }
 
-export default class PriorityQueue implements Queue<PriorityQueueOptions> {
+export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOptions> {
 	private readonly _queue: Array<PriorityQueueOptions & {run: RunFunction}> = [];
 
 	enqueue(run: RunFunction, options?: Partial<PriorityQueueOptions>): void {
@@ -34,8 +34,8 @@ export default class PriorityQueue implements Queue<PriorityQueueOptions> {
 		return item && item.run;
 	}
 
-	filter(options: Partial<PriorityQueueOptions>): Array<{}> {
-		return this._queue.filter(element => element.priority === options.priority);
+	filter(options: Partial<PriorityQueueOptions>): RunFunction[] {
+		return this._queue.filter(element => element.priority === options.priority).map(element => element.run);
 	}
 
 	get size(): number {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -34,6 +34,10 @@ export default class PriorityQueue implements Queue<PriorityQueueOptions> {
 		return item && item.run;
 	}
 
+	sizeBy(options: Partial<PriorityQueueOptions>): number {
+		return this._queue.filter(element => element.priority === options.priority).length;
+	}
+
 	get size(): number {
 		return this._queue.length;
 	}

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -2,6 +2,7 @@ export type RunFunction = () => Promise<unknown>;
 
 export interface Queue<Options> {
 	size: number;
+	sizeBy(options: Partial<Options>): number;
 	dequeue(): RunFunction | undefined;
 	enqueue(run: RunFunction, options?: Partial<Options>): void;
 }

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -1,8 +1,8 @@
 export type RunFunction = () => Promise<unknown>;
 
-export interface Queue<Options> {
+export interface Queue<Element, Options> {
 	size: number;
-	filter(options: Partial<Options>): Array<{}>;
-	dequeue(): RunFunction | undefined;
-	enqueue(run: RunFunction, options?: Partial<Options>): void;
+	filter(options: Partial<Options>): Element[];
+	dequeue(): Element | undefined;
+	enqueue(run: Element, options?: Partial<Options>): void;
 }

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -2,7 +2,7 @@ export type RunFunction = () => Promise<unknown>;
 
 export interface Queue<Options> {
 	size: number;
-	sizeBy(options: Partial<Options>): number;
+	filter(options: Partial<Options>): Array<{}>;
 	dequeue(): RunFunction | undefined;
 	enqueue(run: RunFunction, options?: Partial<Options>): void;
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -103,6 +103,20 @@ test('.add() - priority', async t => {
 	t.deepEqual(result, [1, 3, 1, 2, 0, 0]);
 });
 
+test('.sizeBy() - priority', async t => {
+	const queue = new PQueue();
+	queue.pause();
+	queue.add(async () => 0, {priority: 1});
+	queue.add(async () => 0, {priority: 0});
+	queue.add(async () => 0, {priority: 1});
+	t.is(queue.sizeBy({priority: 1}), 2);
+	t.is(queue.sizeBy({priority: 0}), 1);
+	queue.clear();
+	await queue.onEmpty();
+	t.is(queue.sizeBy({priority: 1}), 0);
+	t.is(queue.sizeBy({priority: 0}), 0);
+});
+
 test('.add() - timeout without throwing', async t => {
 	const result: string[] = [];
 	const queue = new PQueue({timeout: 300, throwOnTimeout: false});


### PR DESCRIPTION
Thanks for a great and useful library.

We use `p-queue` to totally order all of the web requests our app makes. However this means that there is a risk that when the user closes the tab, there is some work left pending in the promise queue.

We use priority to discern between important requests (eg. a user action) and unimportant requests (eg. updating something unimportant in the background).

We use an `onbeforeunload` hook to warn the user that they could lose changes if `queue.size > 0`. However it would be an improvement to user experience if we could only warn them if the queue contains very important actions (based on priority). This is what motivated me to implement `sizeBy`, which takes the same priority options as `add`, and filters the results.

Interested to hear what you think! 