### PR TITLE
Add Promise resolve to _queue.enqueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 yarn.lock
 .nyc_output
-dist

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,101 @@
+import EventEmitter = require('eventemitter3');
+import { Queue, RunFunction } from './queue';
+import PriorityQueue from './priority-queue';
+import { QueueAddOptions, DefaultAddOptions, Options } from './options';
+declare type Task<TaskResultType> = (() => PromiseLike<TaskResultType>) | (() => TaskResultType);
+/**
+Promise queue with concurrency control.
+*/
+export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsType> = PriorityQueue, EnqueueOptionsType extends QueueAddOptions = DefaultAddOptions> extends EventEmitter<'active'> {
+    private readonly _carryoverConcurrencyCount;
+    private readonly _isIntervalIgnored;
+    private _intervalCount;
+    private readonly _intervalCap;
+    private readonly _interval;
+    private _intervalEnd;
+    private _intervalId?;
+    private _timeoutId?;
+    private _queue;
+    private readonly _queueClass;
+    private _pendingCount;
+    private _concurrency;
+    private _isPaused;
+    private _resolveEmpty;
+    private _resolveIdle;
+    private _timeout?;
+    private readonly _throwOnTimeout;
+    constructor(options?: Options<QueueType, EnqueueOptionsType>);
+    private get _doesIntervalAllowAnother();
+    private get _doesConcurrentAllowAnother();
+    private _next;
+    private _resolvePromises;
+    private _onResumeInterval;
+    private _isIntervalPaused;
+    private _tryToStartAnother;
+    private _initializeIntervalIfNeeded;
+    private _onInterval;
+    /**
+    Executes all queued functions until it reaches the limit.
+    */
+    private _processQueue;
+    get concurrency(): number;
+    set concurrency(newConcurrency: number);
+    /**
+    Adds a sync or async task to the queue. Always returns a promise.
+    */
+    add<TaskResultType>(fn: Task<TaskResultType>, options?: Partial<EnqueueOptionsType>): Promise<TaskResultType>;
+    /**
+    Same as `.add()`, but accepts an array of sync or async functions.
+
+    @returns A promise that resolves when all functions are resolved.
+    */
+    addAll<TaskResultsType>(functions: ReadonlyArray<Task<TaskResultsType>>, options?: EnqueueOptionsType): Promise<TaskResultsType[]>;
+    /**
+    Start (or resume) executing enqueued tasks within concurrency limit. No need to call this if queue is not paused (via `options.autoStart = false` or by `.pause()` method.)
+    */
+    start(): this;
+    /**
+    Put queue execution on hold.
+    */
+    pause(): void;
+    /**
+    Clear the queue.
+    */
+    clear(): void;
+    /**
+    Can be called multiple times. Useful if you for example add additional items at a later time.
+
+    @returns A promise that settles when the queue becomes empty.
+    */
+    onEmpty(): Promise<void>;
+    /**
+    The difference with `.onEmpty` is that `.onIdle` guarantees that all work from the queue has finished. `.onEmpty` merely signals that the queue is empty, but it could mean that some promises haven't completed yet.
+
+    @returns A promise that settles when the queue becomes empty, and all promises have completed; `queue.size === 0 && queue.pending === 0`.
+    */
+    onIdle(): Promise<void>;
+    /**
+    Size of the queue.
+    */
+    get size(): number;
+    /**
+    Size of the queue, filtered by the given options.
+
+    For example, this can be used to find the number of items remaining in the queue with a specific priority level.
+    */
+    sizeBy(options: Partial<EnqueueOptionsType>): number;
+    /**
+    Number of pending promises.
+    */
+    get pending(): number;
+    /**
+    Whether the queue is currently paused.
+    */
+    get isPaused(): boolean;
+    /**
+    Set the timeout for future operations.
+    */
+    set timeout(milliseconds: number | undefined);
+    get timeout(): number | undefined;
+}
+export { Queue, QueueAddOptions, DefaultAddOptions, Options };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,371 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const EventEmitter = require("eventemitter3");
+const p_timeout_1 = require("p-timeout");
+const priority_queue_1 = require("./priority-queue");
+const empty = () => { };
+const timeoutError = new p_timeout_1.TimeoutError();
+/**
+Promise queue with concurrency control.
+*/
+class PQueue extends EventEmitter {
+    constructor(options) {
+        super();
+        Object.defineProperty(this, "_carryoverConcurrencyCount", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_isIntervalIgnored", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_intervalCount", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: 0
+        });
+        Object.defineProperty(this, "_intervalCap", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_interval", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_intervalEnd", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: 0
+        });
+        Object.defineProperty(this, "_intervalId", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_timeoutId", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_queue", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_queueClass", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_pendingCount", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: 0
+        });
+        // The `!` is needed because of https://github.com/microsoft/TypeScript/issues/32194
+        Object.defineProperty(this, "_concurrency", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_isPaused", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_resolveEmpty", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: empty
+        });
+        Object.defineProperty(this, "_resolveIdle", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: empty
+        });
+        Object.defineProperty(this, "_timeout", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        Object.defineProperty(this, "_throwOnTimeout", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+        // eslint-disable-next-line @typescript-eslint/no-object-literal-type-assertion
+        options = Object.assign({ carryoverConcurrencyCount: false, intervalCap: Infinity, interval: 0, concurrency: Infinity, autoStart: true, queueClass: priority_queue_1.default }, options
+        // TODO: Remove this `as`.
+        );
+        if (!(typeof options.intervalCap === 'number' && options.intervalCap >= 1)) {
+            throw new TypeError(`Expected \`intervalCap\` to be a number from 1 and up, got \`${options.intervalCap}\` (${typeof options.intervalCap})`);
+        }
+        if (options.interval === undefined || !(Number.isFinite(options.interval) && options.interval >= 0)) {
+            throw new TypeError(`Expected \`interval\` to be a finite number >= 0, got \`${options.interval}\` (${typeof options.interval})`);
+        }
+        this._carryoverConcurrencyCount = options.carryoverConcurrencyCount;
+        this._isIntervalIgnored = options.intervalCap === Infinity || options.interval === 0;
+        this._intervalCap = options.intervalCap;
+        this._interval = options.interval;
+        this._queue = new options.queueClass();
+        this._queueClass = options.queueClass;
+        this.concurrency = options.concurrency;
+        this._timeout = options.timeout;
+        this._throwOnTimeout = options.throwOnTimeout === true;
+        this._isPaused = options.autoStart === false;
+    }
+    get _doesIntervalAllowAnother() {
+        return this._isIntervalIgnored || this._intervalCount < this._intervalCap;
+    }
+    get _doesConcurrentAllowAnother() {
+        return this._pendingCount < this._concurrency;
+    }
+    _next() {
+        this._pendingCount--;
+        this._tryToStartAnother();
+    }
+    _resolvePromises() {
+        this._resolveEmpty();
+        this._resolveEmpty = empty;
+        if (this._pendingCount === 0) {
+            this._resolveIdle();
+            this._resolveIdle = empty;
+        }
+    }
+    _onResumeInterval() {
+        this._onInterval();
+        this._initializeIntervalIfNeeded();
+        this._timeoutId = undefined;
+    }
+    _isIntervalPaused() {
+        const now = Date.now();
+        if (this._intervalId === undefined) {
+            const delay = this._intervalEnd - now;
+            if (delay < 0) {
+                // Act as the interval was done
+                // We don't need to resume it here because it will be resumed on line 160
+                this._intervalCount = (this._carryoverConcurrencyCount) ? this._pendingCount : 0;
+            }
+            else {
+                // Act as the interval is pending
+                if (this._timeoutId === undefined) {
+                    this._timeoutId = setTimeout(() => {
+                        this._onResumeInterval();
+                    }, delay);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+    _tryToStartAnother() {
+        if (this._queue.size === 0) {
+            // We can clear the interval ("pause")
+            // Because we can redo it later ("resume")
+            if (this._intervalId) {
+                clearInterval(this._intervalId);
+            }
+            this._intervalId = undefined;
+            this._resolvePromises();
+            return false;
+        }
+        if (!this._isPaused) {
+            const canInitializeInterval = !this._isIntervalPaused();
+            if (this._doesIntervalAllowAnother && this._doesConcurrentAllowAnother) {
+                this.emit('active');
+                this._queue.dequeue()();
+                if (canInitializeInterval) {
+                    this._initializeIntervalIfNeeded();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+    _initializeIntervalIfNeeded() {
+        if (this._isIntervalIgnored || this._intervalId !== undefined) {
+            return;
+        }
+        this._intervalId = setInterval(() => {
+            this._onInterval();
+        }, this._interval);
+        this._intervalEnd = Date.now() + this._interval;
+    }
+    _onInterval() {
+        if (this._intervalCount === 0 && this._pendingCount === 0 && this._intervalId) {
+            clearInterval(this._intervalId);
+            this._intervalId = undefined;
+        }
+        this._intervalCount = this._carryoverConcurrencyCount ? this._pendingCount : 0;
+        this._processQueue();
+    }
+    /**
+    Executes all queued functions until it reaches the limit.
+    */
+    _processQueue() {
+        // eslint-disable-next-line no-empty
+        while (this._tryToStartAnother()) { }
+    }
+    get concurrency() {
+        return this._concurrency;
+    }
+    set concurrency(newConcurrency) {
+        if (!(typeof newConcurrency === 'number' && newConcurrency >= 1)) {
+            throw new TypeError(`Expected \`concurrency\` to be a number from 1 and up, got \`${newConcurrency}\` (${typeof newConcurrency})`);
+        }
+        this._concurrency = newConcurrency;
+        this._processQueue();
+    }
+    /**
+    Adds a sync or async task to the queue. Always returns a promise.
+    */
+    async add(fn, options = {}) {
+        let result;
+        return new Promise((resolve, reject) => {
+            const run = async () => {
+                this._pendingCount++;
+                this._intervalCount++;
+                try {
+                    const operation = (this._timeout === undefined && options.timeout === undefined) ? fn() : p_timeout_1.default(Promise.resolve(fn()), (options.timeout === undefined ? this._timeout : options.timeout), () => {
+                        if (options.throwOnTimeout === undefined ? this._throwOnTimeout : options.throwOnTimeout) {
+                            reject(timeoutError);
+                        }
+                        return undefined;
+                    });
+                    result = await operation;
+                    resolve(result);
+                }
+                catch (error) {
+                    reject(error);
+                }
+                this._next();
+            };
+            this._queue.enqueue(run, options, resolve);
+            this._tryToStartAnother();
+        });
+    }
+    /**
+    Same as `.add()`, but accepts an array of sync or async functions.
+
+    @returns A promise that resolves when all functions are resolved.
+    */
+    async addAll(functions, options) {
+        return Promise.all(functions.map(async (function_) => this.add(function_, options)));
+    }
+    /**
+    Start (or resume) executing enqueued tasks within concurrency limit. No need to call this if queue is not paused (via `options.autoStart = false` or by `.pause()` method.)
+    */
+    start() {
+        if (!this._isPaused) {
+            return this;
+        }
+        this._isPaused = false;
+        this._processQueue();
+        return this;
+    }
+    /**
+    Put queue execution on hold.
+    */
+    pause() {
+        this._isPaused = true;
+    }
+    /**
+    Clear the queue.
+    */
+    clear() {
+        this._queue = new this._queueClass();
+    }
+    /**
+    Can be called multiple times. Useful if you for example add additional items at a later time.
+
+    @returns A promise that settles when the queue becomes empty.
+    */
+    async onEmpty() {
+        // Instantly resolve if the queue is empty
+        if (this._queue.size === 0) {
+            return;
+        }
+        return new Promise(resolve => {
+            const existingResolve = this._resolveEmpty;
+            this._resolveEmpty = () => {
+                existingResolve();
+                resolve();
+            };
+        });
+    }
+    /**
+    The difference with `.onEmpty` is that `.onIdle` guarantees that all work from the queue has finished. `.onEmpty` merely signals that the queue is empty, but it could mean that some promises haven't completed yet.
+
+    @returns A promise that settles when the queue becomes empty, and all promises have completed; `queue.size === 0 && queue.pending === 0`.
+    */
+    async onIdle() {
+        // Instantly resolve if none pending and if nothing else is queued
+        if (this._pendingCount === 0 && this._queue.size === 0) {
+            return;
+        }
+        return new Promise(resolve => {
+            const existingResolve = this._resolveIdle;
+            this._resolveIdle = () => {
+                existingResolve();
+                resolve();
+            };
+        });
+    }
+    /**
+    Size of the queue.
+    */
+    get size() {
+        return this._queue.size;
+    }
+    /**
+    Size of the queue, filtered by the given options.
+
+    For example, this can be used to find the number of items remaining in the queue with a specific priority level.
+    */
+    sizeBy(options) {
+        return this._queue.filter(options).length;
+    }
+    /**
+    Number of pending promises.
+    */
+    get pending() {
+        return this._pendingCount;
+    }
+    /**
+    Whether the queue is currently paused.
+    */
+    get isPaused() {
+        return this._isPaused;
+    }
+    /**
+    Set the timeout for future operations.
+    */
+    set timeout(milliseconds) {
+        this._timeout = milliseconds;
+    }
+    get timeout() {
+        return this._timeout;
+    }
+}
+exports.default = PQueue;

--- a/dist/lower-bound.d.ts
+++ b/dist/lower-bound.d.ts
@@ -1,0 +1,1 @@
+export default function lowerBound<T>(array: readonly T[], value: T, comparator: (a: T, b: T) => number): number;

--- a/dist/lower-bound.js
+++ b/dist/lower-bound.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+// Port of lower_bound from http://en.cppreference.com/w/cpp/algorithm/lower_bound
+// Used to compute insertion index to keep queue sorted after insertion
+function lowerBound(array, value, comparator) {
+    let first = 0;
+    let count = array.length;
+    while (count > 0) {
+        const step = (count / 2) | 0;
+        let it = first + step;
+        if (comparator(array[it], value) <= 0) {
+            first = ++it;
+            count -= step + 1;
+        }
+        else {
+            count = step;
+        }
+    }
+    return first;
+}
+exports.default = lowerBound;

--- a/dist/options.d.ts
+++ b/dist/options.d.ts
@@ -1,0 +1,64 @@
+import { Queue, RunFunction } from './queue';
+export interface QueueAddOptions {
+    readonly [key: string]: unknown;
+}
+export interface Options<QueueType extends Queue<RunFunction, QueueOptions>, QueueOptions extends QueueAddOptions> {
+    /**
+    Concurrency limit.
+
+    Minimum: `1`.
+
+    @default Infinity
+    */
+    readonly concurrency?: number;
+    /**
+    Whether queue tasks within concurrency limit, are auto-executed as soon as they're added.
+
+    @default true
+    */
+    readonly autoStart?: boolean;
+    /**
+    Class with a `enqueue` and `dequeue` method, and a `size` getter. See the [Custom QueueClass](https://github.com/sindresorhus/p-queue#custom-queueclass) section.
+    */
+    readonly queueClass?: new () => QueueType;
+    /**
+    The max number of runs in the given interval of time.
+
+    Minimum: `1`.
+
+    @default Infinity
+    */
+    readonly intervalCap?: number;
+    /**
+    The length of time in milliseconds before the interval count resets. Must be finite.
+
+    Minimum: `0`.
+
+    @default 0
+    */
+    readonly interval?: number;
+    /**
+    Whether the task must finish in the given interval or will be carried over into the next interval count.
+
+    @default false
+    */
+    readonly carryoverConcurrencyCount?: boolean;
+    /**
+    Per-operation timeout in milliseconds. Operations fulfill once `timeout` elapses if they haven't already.
+    */
+    timeout?: number;
+    /**
+    Whether or not a timeout is considered an exception.
+
+    @default false
+    */
+    throwOnTimeout?: boolean;
+}
+export interface DefaultAddOptions extends QueueAddOptions {
+    /**
+    Priority of operation. Operations with greater priority will be scheduled first.
+
+    @default 0
+    */
+    readonly priority?: number;
+}

--- a/dist/options.js
+++ b/dist/options.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/priority-queue.d.ts
+++ b/dist/priority-queue.d.ts
@@ -1,0 +1,12 @@
+import { Queue, RunFunction } from './queue';
+import { QueueAddOptions } from './options';
+export interface PriorityQueueOptions extends QueueAddOptions {
+    priority?: number;
+}
+export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOptions> {
+    private readonly _queue;
+    enqueue(run: RunFunction, options?: Partial<PriorityQueueOptions>): void;
+    dequeue(): RunFunction | undefined;
+    filter(options: Partial<PriorityQueueOptions>): RunFunction[];
+    get size(): number;
+}

--- a/dist/priority-queue.js
+++ b/dist/priority-queue.js
@@ -1,0 +1,37 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const lower_bound_1 = require("./lower-bound");
+class PriorityQueue {
+    constructor() {
+        Object.defineProperty(this, "_queue", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: []
+        });
+    }
+    enqueue(run, options) {
+        options = Object.assign({ priority: 0 }, options);
+        const element = {
+            priority: options.priority,
+            run
+        };
+        if (this.size && this._queue[this.size - 1].priority >= options.priority) {
+            this._queue.push(element);
+            return;
+        }
+        const index = lower_bound_1.default(this._queue, element, (a, b) => b.priority - a.priority);
+        this._queue.splice(index, 0, element);
+    }
+    dequeue() {
+        const item = this._queue.shift();
+        return item && item.run;
+    }
+    filter(options) {
+        return this._queue.filter(element => element.priority === options.priority).map(element => element.run);
+    }
+    get size() {
+        return this._queue.length;
+    }
+}
+exports.default = PriorityQueue;

--- a/dist/queue.d.ts
+++ b/dist/queue.d.ts
@@ -1,0 +1,7 @@
+export declare type RunFunction = () => Promise<unknown>;
+export interface Queue<Element, Options> {
+    size: number;
+    filter(options: Partial<Options>): Element[];
+    dequeue(): Element | undefined;
+    enqueue(run: Element, options?: Partial<Options>): void;
+}

--- a/dist/queue.js
+++ b/dist/queue.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/package.json
+++ b/package.json
@@ -1,89 +1,131 @@
 {
-	"name": "p-queue",
-	"version": "6.3.0",
-	"description": "Promise queue with concurrency control",
-	"license": "MIT",
-	"repository": "sindresorhus/p-queue",
-	"main": "dist/index.js",
-	"engines": {
-		"node": ">=8"
-	},
-	"scripts": {
-		"build": "del dist && tsc",
-		"test": "xo && npm run build && nyc ava",
-		"bench": "ts-node bench.ts",
-		"prepublishOnly": "npm run build"
-	},
-	"files": [
-		"dist"
-	],
-	"types": "dist",
-	"keywords": [
-		"promise",
-		"queue",
-		"enqueue",
-		"limit",
-		"limited",
-		"concurrency",
-		"throttle",
-		"throat",
-		"rate",
-		"batch",
-		"ratelimit",
-		"priority",
-		"priorityqueue",
-		"fifo",
-		"job",
-		"task",
-		"async",
-		"await",
-		"promises",
-		"bluebird"
-	],
-	"dependencies": {
-		"eventemitter3": "^4.0.0",
-		"p-timeout": "^3.1.0"
-	},
-	"devDependencies": {
-		"@sindresorhus/tsconfig": "^0.6.0",
-		"@types/benchmark": "^1.0.31",
-		"@types/node": "^12.12.7",
-		"ava": "^2.0.0",
-		"benchmark": "^2.1.4",
-		"codecov": "^3.3.0",
-		"del-cli": "^3.0.0",
-		"delay": "^4.2.0",
-		"in-range": "^2.0.0",
-		"nyc": "^15.0.0",
-		"random-int": "^2.0.0",
-		"time-span": "^4.0.0",
-		"ts-node": "^8.3.0",
-		"typescript": "3.8.3",
-		"xo": "^0.28.1"
-	},
-	"ava": {
-		"babel": false,
-		"compileEnhancements": false,
-		"extensions": [
-			"ts"
-		],
-		"require": [
-			"ts-node/register"
-		],
-		"files": [
-			"test/**"
-		]
-	},
-	"xo": {
-		"rules": {
-			"@typescript-eslint/member-ordering": "off",
-			"@typescript-eslint/prefer-readonly-parameter-types": "off",
-			"node/no-unsupported-features/es-syntax": "off"
-		}
-	},
-	"nyc": {
-		"extension": [
-			".ts"
-		]
-	}
+  "_from": "p-queue",
+  "_id": "p-queue@6.3.0",
+  "_inBundle": false,
+  "_integrity": "sha512-fg5dJlFpd5+3CgG3/0ogpVZUeJbjiyXFg0nu53hrOYsybqSiDyxyOpad0Rm6tAiGjgztAwkyvhlYHC53OiAJOA==",
+  "_location": "/p-queue",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "p-queue",
+    "name": "p-queue",
+    "escapedName": "p-queue",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.3.0.tgz",
+  "_shasum": "19bfa4485db7e6a0c135049ff6716375880d9c3a",
+  "_spec": "p-queue",
+  "_where": "/home/tbuntu/Documents/Blockcurators/p-queue-commander",
+  "ava": {
+    "babel": false,
+    "compileEnhancements": false,
+    "extensions": [
+      "ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "files": [
+      "test/**"
+    ]
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/p-queue/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "eventemitter3": "^4.0.0",
+    "p-timeout": "^3.1.0"
+  },
+  "deprecated": false,
+  "description": "Promise queue with concurrency control",
+  "devDependencies": {
+    "@sindresorhus/tsconfig": "^0.6.0",
+    "@types/benchmark": "^1.0.31",
+    "@types/node": "^12.12.7",
+    "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "@typescript-eslint/parser": "^1.11.0",
+    "ava": "^2.0.0",
+    "benchmark": "^2.1.4",
+    "codecov": "^3.3.0",
+    "del-cli": "^3.0.0",
+    "delay": "^4.2.0",
+    "eslint-config-xo-typescript": "^0.16.0",
+    "in-range": "^2.0.0",
+    "nyc": "^14.0.0",
+    "random-int": "^2.0.0",
+    "time-span": "^3.1.0",
+    "ts-node": "^8.3.0",
+    "typescript": "3.7.2",
+    "xo": "^0.25.3"
+  },
+  "engines": {
+    "node": ">=8"
+  },
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://github.com/sindresorhus/p-queue#readme",
+  "keywords": [
+    "promise",
+    "queue",
+    "enqueue",
+    "limit",
+    "limited",
+    "concurrency",
+    "throttle",
+    "throat",
+    "rate",
+    "batch",
+    "ratelimit",
+    "priority",
+    "priorityqueue",
+    "fifo",
+    "job",
+    "task",
+    "async",
+    "await",
+    "promises",
+    "bluebird"
+  ],
+  "license": "MIT",
+  "main": "dist/index.js",
+  "name": "p-queue",
+  "nyc": {
+    "extension": [
+      ".ts"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/p-queue.git"
+  },
+  "scripts": {
+    "bench": "ts-node bench.ts",
+    "build": "del dist && tsc",
+    "prepublishOnly": "npm run build",
+    "test": "xo && npm run build && nyc ava"
+  },
+  "types": "dist",
+  "version": "6.3.0",
+  "xo": {
+    "extends": "xo-typescript",
+    "extensions": [
+      "ts"
+    ],
+    "rules": {
+      "@typescript-eslint/member-ordering": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/require-await": "off",
+      "@typescript-eslint/no-misused-promises": "off",
+      "require-atomic-updates": "off"
+    }
+  }
 }

--- a/source/index.ts
+++ b/source/index.ts
@@ -252,7 +252,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 				this._next();
 			};
 
-			this._queue.enqueue(run, options);
+			this._queue.enqueue(run, options, resolve);
 			this._tryToStartAnother();
 		});
 	}

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -4,5 +4,5 @@ export interface Queue<Element, Options> {
 	size: number;
 	filter(options: Partial<Options>): Element[];
 	dequeue(): Element | undefined;
-	enqueue(run: Element, options?: Partial<Options>): void;
+	enqueue(run: Element, options?: Partial<Options>, resolve?: Partial<Options>): void;
 }


### PR DESCRIPTION
this allows for more customized queue types such as a aggregation queue

Aggregation queues work this way: 
- You have only two types of operations in a queue:
  One that is a single operation
  One that is a multi operation

with the constraint that 2+ single operations can be combined to do the same thing as a multi-operation.
And the constraint that a single operation can be combined again with a multi operation.

Demonstrated here on the example of a mocked bitcoin transaction
https://github.com/Totenfluch/p-aggregation-queue/blob/master/index.js

Once I get the merge operations standardised, I will create a pull request for this queue type writte in typescript like the priorityqueue you have in your package

As it is just an additional parameter, nothing should break with this pull request