### PR TITLE
Add `.onSizeLessThan()` helper method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,12 +157,12 @@ The difference with `.onEmpty` is that `.onIdle` guarantees that all work from t
 
 #### .onSizeLessThan(limit)
 
-Returns a promise that settles when the queue size is less than the given limit; `queue.size < limit`.
+Returns a promise that settles when the queue size is less than the given limit: `queue.size < limit`.
 
 If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before
 adding a new item.
 
-Note that this only limits the number of items waiting to start; there could still be up to `concurrency` jobs
+Note that this only limits the number of items waiting to start. There could still be up to `concurrency` jobs
 already running that this call does not include in its calculation.
 
 #### .clear()

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,16 @@ Returns a promise that settles when the queue becomes empty, and all promises ha
 
 The difference with `.onEmpty` is that `.onIdle` guarantees that all work from the queue has finished. `.onEmpty` merely signals that the queue is empty, but it could mean that some promises haven't completed yet.
 
+#### .onSizeLessThan(limit)
+
+Returns a promise that settles when the queue size is less than the given limit; `queue.size < limit`.
+
+If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before
+adding a new item.
+
+Note that this only limits the number of items waiting to start; there could still be up to `concurrency` jobs
+already running that this call does not include in its calculation.
+
 #### .clear()
 
 Clear the queue.

--- a/readme.md
+++ b/readme.md
@@ -159,11 +159,9 @@ The difference with `.onEmpty` is that `.onIdle` guarantees that all work from t
 
 Returns a promise that settles when the queue size is less than the given limit: `queue.size < limit`.
 
-If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before
-adding a new item.
+If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before adding a new item.
 
-Note that this only limits the number of items waiting to start. There could still be up to `concurrency` jobs
-already running that this call does not include in its calculation.
+Note that this only limits the number of items waiting to start. There could still be up to `concurrency` jobs already running that this call does not include in its calculation.
 
 #### .clear()
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -329,14 +329,12 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
-	Returns a promise that settles when the queue size is less than the given limit: `queue.size < limit`.
+	@returns A promise that settles when the queue size is less than the given limit: `queue.size < limit`.
 
-	If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before
-	adding a new item.
+	If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before adding a new item.
 
-	Note that this only limits the number of items waiting to start. There could still be up to `concurrency` jobs
-	already running that this call does not include in its calculation.
-	 */
+	Note that this only limits the number of items waiting to start. There could still be up to `concurrency` jobs already running that this call does not include in its calculation.
+	*/
 	async onSizeLessThan(limit: number): Promise<void> {
 		// Instantly resolve if the queue is empty.
 		if (this._queue.size < limit) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -329,10 +329,14 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
-	Wait for the queue size (the number of items not yet started) to fall below a certain threshold.
+	Returns a promise that settles when the queue size is less than the given limit: `queue.size < limit`.
 
-	@returns A promise that settles when the queue size is below the given limit.
-	*/
+	If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before
+	adding a new item.
+
+	Note that this only limits the number of items waiting to start. There could still be up to `concurrency` jobs
+	already running that this call does not include in its calculation.
+	 */
 	async onSizeLessThan(limit: number): Promise<void> {
 		// Instantly resolve if the queue is empty.
 		if (this._queue.size < limit) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -329,6 +329,29 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
+	Wait for the queue size (the number of items not yet started) to fall below a certain threshold
+
+	@returns A promise that settles when the queue size is below the given limit
+	 */
+	async onSizeLessThan(limit: number): Promise<void> {
+		// Instantly resolve if the queue is empty
+		if (this._queue.size < limit) {
+			return;
+		}
+
+		return new Promise<void>(resolve => {
+			const listener = () => {
+				if (this._queue.size < limit) {
+					this.removeListener('next', listener);
+					resolve();
+				}
+			};
+
+			this.on('next', listener);
+		});
+	}
+
+	/**
 	The difference with `.onEmpty` is that `.onIdle` guarantees that all work from the queue has finished. `.onEmpty` merely signals that the queue is empty, but it could mean that some promises haven't completed yet.
 
 	@returns A promise that settles when the queue becomes empty, and all promises have completed; `queue.size === 0 && queue.pending === 0`.

--- a/source/index.ts
+++ b/source/index.ts
@@ -329,12 +329,12 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
-	Wait for the queue size (the number of items not yet started) to fall below a certain threshold
+	Wait for the queue size (the number of items not yet started) to fall below a certain threshold.
 
-	@returns A promise that settles when the queue size is below the given limit
-	 */
+	@returns A promise that settles when the queue size is below the given limit.
+	*/
 	async onSizeLessThan(limit: number): Promise<void> {
-		// Instantly resolve if the queue is empty
+		// Instantly resolve if the queue is empty.
 		if (this._queue.size < limit) {
 			return;
 		}

--- a/test/test.ts
+++ b/test/test.ts
@@ -225,6 +225,32 @@ test('.onIdle()', async t => {
 	t.is(queue.pending, 0);
 });
 
+test('onSizeLessThan()', async t => {
+	const queue = new PQueue({concurrency: 1});
+
+	queue.add(async () => delay(100));
+	queue.add(async () => delay(100));
+	queue.add(async () => delay(100));
+	queue.add(async () => delay(100));
+	queue.add(async () => delay(100));
+
+	await queue.onSizeLessThan(4);
+	t.is(queue.size, 3);
+	t.is(queue.pending, 1);
+
+	await queue.onSizeLessThan(2);
+	t.is(queue.size, 1);
+	t.is(queue.pending, 1);
+
+	await queue.onSizeLessThan(10);
+	t.is(queue.size, 1);
+	t.is(queue.pending, 1);
+
+	await queue.onSizeLessThan(1);
+	t.is(queue.size, 0);
+	t.is(queue.pending, 1);
+});
+
 test('.onIdle() - no pending', async t => {
 	const queue = new PQueue();
 	t.is(queue.size, 0);

--- a/test/test.ts
+++ b/test/test.ts
@@ -225,7 +225,7 @@ test('.onIdle()', async t => {
 	t.is(queue.pending, 0);
 });
 
-test('onSizeLessThan()', async t => {
+test('.onSizeLessThan()', async t => {
 	const queue = new PQueue({concurrency: 1});
 
 	queue.add(async () => delay(100));


### PR DESCRIPTION
Returns a promise that settles when the queue size is less than the given limit; `queue.size < limit`.

If you want to avoid having the queue grow beyond a certain size you can `await queue.onSizeLessThan()` before
adding a new item.

Note that this only limits the number of items waiting to start; there could still be up to `concurrency` jobs
already running that this call does not include in its calculation.