### PR TITLE
Add ES-module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"scripts": {
 		"build": "del dist && tsc",
-		"postbuild": "ts-node scripts/addESMWrapper.ts",
+		"postbuild": "ts-node scripts/add-esm-wrapper.ts",
 		"test": "xo && npm run build && nyc ava",
 		"bench": "ts-node bench.ts",
 		"prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -6,11 +6,17 @@
 	"repository": "sindresorhus/p-queue",
 	"funding": "https://github.com/sponsors/sindresorhus",
 	"main": "dist/index.js",
+	"module": "dist/wrapper.mjs",
+	"exports": {
+		"import": "./dist/wrapper.mjs",
+		"require": "./dist/index.js"
+	},
 	"engines": {
 		"node": ">=10"
 	},
 	"scripts": {
 		"build": "del dist && tsc",
+		"postbuild": "ts-node scripts/addESMWrapper.ts",
 		"test": "xo && npm run build && nyc ava",
 		"bench": "ts-node bench.ts",
 		"prepublishOnly": "npm run build"

--- a/scripts/add-esm-wrapper.ts
+++ b/scripts/add-esm-wrapper.ts
@@ -1,14 +1,14 @@
 // Adding ESM-wrapper to avoid dual package hazard:
 // https://nodejs.org/api/packages.html#packages_dual_package_hazard
 
-import { writeFileSync } from "fs";
+import {writeFileSync} from 'fs';
 
 const wrapper = `
-import PQueue from "./index.js"
+import PQueue from './index.js'
 export default PQueue.default
 `;
 
-const wrapperPath = "./dist/wrapper.mjs";
+const wrapperPath = './dist/wrapper.mjs';
 
 writeFileSync(wrapperPath, wrapper);
 

--- a/scripts/addESMWrapper.ts
+++ b/scripts/addESMWrapper.ts
@@ -1,0 +1,15 @@
+// Adding ESM-wrapper to avoid dual package hazard:
+// https://nodejs.org/api/packages.html#packages_dual_package_hazard
+
+import { writeFileSync } from "fs";
+
+const wrapper = `
+import PQueue from "./index.js"
+export default PQueue.default
+`;
+
+const wrapperPath = "./dist/wrapper.mjs";
+
+writeFileSync(wrapperPath, wrapper);
+
+console.log(`Added ESM-wrapper: ${wrapperPath}`);


### PR DESCRIPTION
Solves https://github.com/sindresorhus/p-queue/issues/127 by adding ES-module wrapper for CommonJS version.

This approach avoids [dual package hazard](https://nodejs.org/api/packages.html#packages_dual_package_hazard) by creating `wrapper.mjs` file in a `dist` folder after successful build. See https://nodejs.org/api/packages.html#packages_approach_1_use_an_es_module_wrapper
