### PR TITLE
Fixed `package.json` not exported error and warnings when using this library

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
 	"repository": "sindresorhus/p-queue",
 	"funding": "https://github.com/sponsors/sindresorhus",
 	"type": "module",
-	"exports": "./dist/index.js",
+	"exports": {
+		".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
 	"engines": {
 		"node": ">=12"
 	},

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 	"type": "module",
 	"exports": {
 		".": "./dist/index.js",
-    "./package.json": "./package.json"
-  },
+		"./package.json": "./package.json"
+	},
 	"engines": {
 		"node": ">=12"
 	},


### PR DESCRIPTION
Package.json should export itself has well as the js file. Without it, bundlers such as rollup will complain about it, see eg. below. This PR fixes it by exporting both.

Eg.:
[rollup-plugin-svelte] The following packages did not export their `package.json` file so we could not check the "svelte" field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.
