### PR TITLE
Add main to package.json for lookup compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"repository": "sindresorhus/p-queue",
 	"funding": "https://github.com/sponsors/sindresorhus",
 	"type": "module",
+	"main": ".dist/index.js",
 	"exports": "./dist/index.js",
 	"engines": {
 		"node": ">=12"


### PR DESCRIPTION
this fixes #134. I'll update fuse-box to look for the exports field as well in package.jsons