### PR TITLE
Added ability to stop processing when task returns an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"license": "MIT",
 	"repository": "sindresorhus/p-queue",
 	"funding": "https://github.com/sponsors/sindresorhus",
-	"type": "module",
 	"exports": "./dist/index.js",
 	"engines": {
 		"node": ">=12"

--- a/source/options.ts
+++ b/source/options.ts
@@ -13,6 +13,13 @@ export interface Options<QueueType extends Queue<RunFunction, QueueOptions>, Que
 	readonly concurrency?: number;
 
 	/**
+	Should we stop processing if we encounter an error
+
+	@default false
+	*/
+	readonly pauseOnError?: boolean;
+
+	/**
 	Whether queue tasks within concurrency limit, are auto-executed as soon as they're added.
 
 	@default true


### PR DESCRIPTION
Hey, 
As the title says, this adds an option to be able to stop processing when we encounter an error.
This is quite important for me as i'm trying to do a fifo queue that stops on error.

Ta
