### PR TITLE
Allow `.sizeBy()` to filter for any option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,12 @@ Default: `0`
 
 Priority of operation. Operations with greater priority will be scheduled first.
 
+##### any other key
+
+Type: `object`
+
+You can pass any keys in options to use then later in sizeBy filtering
+
 #### .addAll(fns, options?)
 
 Same as `.add()`, but accepts an array of sync or async functions and returns a promise that resolves when all functions are resolved.
@@ -177,7 +183,7 @@ Size of the queue, the number of queued items waiting to run.
 
 Size of the queue, filtered by the given options.
 
-For example, this can be used to find the number of items remaining in the queue with a specific priority level.
+For example, this can be used to find the number of items remaining in the queue with a specific priority level or any other field.
 
 ```js
 import PQueue from 'p-queue';

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ Priority of operation. Operations with greater priority will be scheduled first.
 
 Type: `object`
 
-You can pass any keys in options to use then later in sizeBy filtering
+You can pass any keys in options to use then later in `sizeBy` filtering.
 
 #### .addAll(fns, options?)
 

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -1,6 +1,7 @@
 import {Queue, RunFunction} from './queue.js';
 import lowerBound from './lower-bound.js';
 import {QueueAddOptions} from './options.js';
+import {shallowPartialEqual} from './shallow-equal.js';
 
 export interface PriorityQueueOptions extends QueueAddOptions {
 	priority?: number;
@@ -16,8 +17,8 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 		};
 
 		const element = {
-			priority: options.priority,
 			run,
+			...options,
 		};
 
 		if (this.size && this._queue[this.size - 1]!.priority! >= options.priority!) {
@@ -39,7 +40,7 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 
 	filter(options: Readonly<Partial<PriorityQueueOptions>>): RunFunction[] {
 		return this._queue.filter(
-			(element: Readonly<PriorityQueueOptions>) => element.priority === options.priority,
+			(element: Readonly<PriorityQueueOptions>) => shallowPartialEqual(options, element),
 		).map((element: Readonly<{run: RunFunction}>) => element.run);
 	}
 

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -17,8 +17,8 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 		};
 
 		const element = {
-			run,
 			...options,
+			run,
 		};
 
 		if (this.size && this._queue[this.size - 1]!.priority! >= options.priority!) {

--- a/source/shallow-equal.ts
+++ b/source/shallow-equal.ts
@@ -1,7 +1,6 @@
-export function shallowPartialEqual(object1: any, object2: any) {
-	const keys1 = Object.keys(object1);
-	for (const key of keys1) {
-		if (object1[key] !== object2[key]) {
+export function shallowPartialEqual(object1: Record<string, unknown>, object2: Record<string, unknown>) {
+	for (const [key, value] of Object.entries(object1)) {
+		if (value !== object2[key]) {
 			return false;
 		}
 	}

--- a/source/shallow-equal.ts
+++ b/source/shallow-equal.ts
@@ -1,0 +1,10 @@
+export function shallowPartialEqual(object1: any, object2: any) {
+	const keys1 = Object.keys(object1);
+	for (const key of keys1) {
+		if (object1[key] !== object2[key]) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -118,6 +118,19 @@ test('.sizeBy() - priority', async t => {
 	t.is(queue.sizeBy({priority: 0}), 0);
 });
 
+test('.sizeBy() - uid', async t => {
+	const queue = new PQueue();
+	queue.pause();
+	queue.add(async () => 0, {uid: '341a0c1b-147a-4b8e-9b9d-186773918a25'});
+	queue.add(async () => 0, {uid: '07227c1e-0476-46b5-bd5b-5436626ede16'});
+	queue.add(async () => 0, {uid: '341a0c1b-147a-4b8e-9b9d-186773918a25'});
+	t.is(queue.sizeBy({uid: '341a0c1b-147a-4b8e-9b9d-186773918a25'}), 2);
+	t.is(queue.sizeBy({uid: '07227c1e-0476-46b5-bd5b-5436626ede16'}), 1);
+	queue.clear();
+	await queue.onEmpty();
+	t.is(queue.sizeBy({uid: '341a0c1b-147a-4b8e-9b9d-186773918a25'}), 0);
+	t.is(queue.sizeBy({uid: '07227c1e-0476-46b5-bd5b-5436626ede16'}), 0);
+});
 test('.add() - timeout without throwing', async t => {
 	const result: string[] = [];
 	const queue = new PQueue({timeout: 300, throwOnTimeout: false});

--- a/test/test.ts
+++ b/test/test.ts
@@ -131,6 +131,7 @@ test('.sizeBy() - uid', async t => {
 	t.is(queue.sizeBy({uid: '341a0c1b-147a-4b8e-9b9d-186773918a25'}), 0);
 	t.is(queue.sizeBy({uid: '07227c1e-0476-46b5-bd5b-5436626ede16'}), 0);
 });
+
 test('.add() - timeout without throwing', async t => {
 	const result: string[] = [];
 	const queue = new PQueue({timeout: 300, throwOnTimeout: false});


### PR DESCRIPTION
queue.sizeBy currently supports filtering by priority only
it could be extended to any prop
e.g.
```javascript
const options = { uid: '341a0c1b-147a-4b8e-9b9d-186773918a25' };
queue.add(() => delay(2000), options);
console.log('size by', queue.sizeBy({ uid: '341a0c1b-147a-4b8e-9b9d-186773918a25' }));
```