### PR TITLE
Add main property to fix importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"bench": "node --loader=ts-node/esm bench.ts",
 		"prepare": "npm run build"
 	},
+	"main": "./dist/index.js",
 	"files": [
 		"dist"
 	],


### PR DESCRIPTION
If omitted, `main` defaults to `index.js`, see https://docs.npmjs.com/cli/v8/configuring-npm/package-json/#main.

Since `index.js` resides in `dist` for this repo, omitting the `main` keyword will make the import fail. This is causing the problems described in https://github.com/sindresorhus/p-queue/issues/145#issuecomment-851873084. With this keyword properly set, importing with
```js 
import PQueue from 'p-queue'
```
instead of
```js
import PQueue from 'p-queue/dist/index'
```
works again.

cc @skjnldsv @artonge since you had issues with this in https://github.com/nextcloud/server/pull/28127#discussion_r676407842