### PR TITLE
Fix timeout-dependent return types of `add` and `addAll`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,9 @@ Per-operation timeout in milliseconds. Operations fulfill once `timeout` elapses
 Type: `boolean`\
 Default: `false`
 
-Whether or not a timeout is considered an exception. This option only has an effect when `timeout` is defined.
+Whether or not a timeout is considered an exception. When `false`, promises will resolve without a value on timeout.
+
+Obviously, this option only has an effect when `timeout` is defined.
 
 ##### autoStart
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,8 @@ Concurrency limit.
 
 ##### timeout
 
-Type: `number`
+Type: `number`\
+Default: `undefined` (i.e. no timeout is enforced)
 
 Per-operation timeout in milliseconds. Operations fulfill once `timeout` elapses if they haven't already.
 
@@ -72,7 +73,7 @@ Per-operation timeout in milliseconds. Operations fulfill once `timeout` elapses
 Type: `boolean`\
 Default: `false`
 
-Whether or not a timeout is considered an exception.
+Whether or not a timeout is considered an exception. This option only has an effect when `timeout` is defined.
 
 ##### autoStart
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -50,7 +50,6 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	*/
 	timeout?: number;
 
-	// TODO: The `throwOnTimeout` option should affect the return types of `add()` and `addAll()`
 	constructor(options?: Options<QueueType, EnqueueOptionsType>) {
 		super();
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -50,6 +50,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	*/
 	timeout?: number;
 
+	// TODO: The `throwOnTimeout` option should affect the return types of `add()` and `addAll()`
 	constructor(options?: Options<QueueType, EnqueueOptionsType>) {
 		super();
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,7 +2,7 @@ import {EventEmitter} from 'eventemitter3';
 import pTimeout, {TimeoutError} from 'p-timeout';
 import {type Queue, type RunFunction} from './queue.js';
 import PriorityQueue from './priority-queue.js';
-import {type QueueAddOptions, type Options, type TaskOptions} from './options.js';
+import {type QueueAddOptions, type Options, type TaskOptions, type WithoutTimeout, type WithoutTimeoutThrow, type WithTimeoutThrow} from './options.js';
 
 type Task<TaskResultType> =
 	| ((options: TaskOptions) => PromiseLike<TaskResultType>)
@@ -231,9 +231,22 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	/**
 	Adds a sync or async task to the queue. Always returns a promise.
 	*/
-	async add<TaskResultType>(function_: Task<TaskResultType>, options: {throwOnTimeout: true} & Exclude<EnqueueOptionsType, 'throwOnTimeout'>): Promise<TaskResultType>;
-	async add<TaskResultType>(function_: Task<TaskResultType>, options?: Partial<EnqueueOptionsType>): Promise<TaskResultType | void>;
-	async add<TaskResultType>(function_: Task<TaskResultType>, options: Partial<EnqueueOptionsType> = {}): Promise<TaskResultType | void> {
+	async add<TaskResultType>(
+		function_: Task<TaskResultType>,
+		options?: WithoutTimeout<Partial<EnqueueOptionsType>>
+	): Promise<TaskResultType>;
+	async add<TaskResultType>(
+		function_: Task<TaskResultType>,
+		options: WithTimeoutThrow<Partial<EnqueueOptionsType>>
+	): Promise<TaskResultType>;
+	async add<TaskResultType>(
+		function_: Task<TaskResultType>,
+		options: WithoutTimeoutThrow<Partial<EnqueueOptionsType>>
+	): Promise<TaskResultType | void>;
+	async add<TaskResultType>(
+		function_: Task<TaskResultType>,
+		options: Partial<EnqueueOptionsType> = {},
+	): Promise<TaskResultType | void> {
 		options = {
 			timeout: this.timeout,
 			throwOnTimeout: this.#throwOnTimeout,

--- a/source/index.ts
+++ b/source/index.ts
@@ -252,6 +252,10 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 			...options,
 		};
 
+		if (!options.timeout && options.throwOnTimeout) {
+			console.warn('You specified `throwOnTimeout=true` without defining `timeout`.');
+		}
+
 		return new Promise((resolve, reject) => {
 			this.#queue.enqueue(async () => {
 				this.#pending++;

--- a/source/index.ts
+++ b/source/index.ts
@@ -300,15 +300,19 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	*/
 	async addAll<TaskResultsType>(
 		functions: ReadonlyArray<Task<TaskResultsType>>,
-		options?: {throwOnTimeout: true} & Partial<Exclude<EnqueueOptionsType, 'throwOnTimeout'>>,
+		options?: WithoutTimeout<Partial<EnqueueOptionsType>>,
 	): Promise<TaskResultsType[]>;
 	async addAll<TaskResultsType>(
 		functions: ReadonlyArray<Task<TaskResultsType>>,
-		options?: Partial<EnqueueOptionsType>,
+		options: WithTimeoutThrow<Partial<EnqueueOptionsType>>
+	): Promise<TaskResultsType[]>;
+	async addAll<TaskResultsType>(
+		functions: ReadonlyArray<Task<TaskResultsType>>,
+		options: WithoutTimeoutThrow<Partial<EnqueueOptionsType>>,
 	): Promise<Array<TaskResultsType | void>>;
 	async addAll<TaskResultsType>(
 		functions: ReadonlyArray<Task<TaskResultsType>>,
-		options?: Partial<EnqueueOptionsType>,
+		options: Partial<EnqueueOptionsType> = {},
 	): Promise<Array<TaskResultsType | void>> {
 		return Promise.all(functions.map(async function_ => this.add(function_, options)));
 	}

--- a/source/options.ts
+++ b/source/options.ts
@@ -109,3 +109,23 @@ export type TaskOptions = {
 	*/
 	readonly signal?: AbortSignal;
 };
+
+/**
+Helper type to target the case where timeout=number.
+*/
+export type WithTimeout<Options> = Options & {timeout: number};
+
+/**
+Helper type to target the case where timeout=undefined.
+*/
+export type WithoutTimeout<Options> = Omit<Options, 'timeout'> | {timeout: undefined};
+
+/**
+Helper type to target the case where timeout=number and throwOnTimeout=true.
+*/
+export type WithTimeoutThrow<Options> = WithTimeout<Options> & {throwOnTimeout: true};
+
+/**
+Helper type to target the case where timeout=number and throwOnTimeout=false/undefined.
+*/
+export type WithoutTimeoutThrow<Options> = WithTimeout<Options> & {throwOnTimeout?: false};

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -3,5 +3,14 @@ import PQueue from '../source/index.js';
 
 const queue = new PQueue();
 
-expectType<Promise<string | void>>(queue.add(async () => '🦄'));
+expectType<Promise<string>>(queue.add(async () => '🦄'));
+expectType<Promise<string>>(queue.add(async () => '🦄', {}));
+expectType<Promise<string>>(queue.add(async () => '🦄', {throwOnTimeout: undefined}));
+expectType<Promise<string>>(queue.add(async () => '🦄', {throwOnTimeout: false}));
 expectType<Promise<string>>(queue.add(async () => '🦄', {throwOnTimeout: true}));
+expectType<Promise<string>>(queue.add(async () => '🦄', {timeout: undefined}));
+expectType<Promise<string>>(queue.add(async () => '🦄', {timeout: 1, throwOnTimeout: true}));
+expectType<Promise<string | void>>(queue.add(async () => '🦄', {timeout: 1}));
+expectType<Promise<string | void>>(queue.add(async () => '🦄', {timeout: 1, throwOnTimeout: undefined}));
+expectType<Promise<string | void>>(queue.add(async () => '🦄', {timeout: 1, throwOnTimeout: false}));
+expectType<Promise<string>>(queue.add(async () => '🦄', {priority: 1}));


### PR DESCRIPTION
Hi. The return types of `add` and `addAll` are currently a bit funky. I think there was a regression.

For example, the following code raises a type error for `b` because it thinks `a` is `number | void`:

```ts
const a = await this.queue.add(async () => 1);
const b: number = a * 2;
```

That doesn't seem right. It should only return `number | void` when both `timeout=number` and `throwOnTimeout=false|undefined`. But in the example above I haven't even specified `timeout`, so the `void` behavior should never surface. 

This PR fixes the return types:

- When `timeout=number` and `throwOnTimeout=true`, return type is `Thing`.
- When `timeout=number` and `throwOnTimeout=false|undefined`, return type is `Thing | void`.
- When `timeout=undefined` and `throwOnTimeout=true|false|undefined`, return type is `Thing`.

To further emphasize the relationship between `timeout` and `throwOnTimeout` I also added a note in the readme and a warning message in the console.