### PR TITLE
Add `.setPriority()` for updating priority of a queued promise function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,12 @@ Default: `0`
 
 Priority of operation. Operations with greater priority will be scheduled first.
 
+##### id
+
+Type `string`
+
+Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned as an incrementing bigint starting from 1n.
+
 ##### signal
 
 [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for cancellation of the operation. When aborted, it will be removed from the queue and the `queue.add()` call will reject with an [error](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason). If the operation is already running, the signal will need to be handled by the operation itself.
@@ -238,11 +244,9 @@ console.log(queue.sizeBy({priority: 0}));
 
 #### .setPriority(id, priority)
 
-Update priority of a known promise function, using the `id` identifier, and a priority value to override existing priority value. The updated value of priority ensures whether to execute this promise function sooner or later.
+Updates the priority of a promise function by its id, affecting its execution order. Requires a defined concurrency limit to take effect.
 
-Function works only when we specify a defined concurrency to change any priorities.
-
-For example, this can be used to make a promise function run earlier.
+For example, this can be used to prioritize a promise function to run earlier.
 
 ```js
 import PQueue from 'p-queue';
@@ -256,9 +260,9 @@ queue.add(async () => '🦄', {priority: 1});
 
 queue.setPriority('🦀', 2);
 ```
-In above case, promise function with '🦀' executes second.
+In this case, the promise function with id: '🦀' runs second.
 
-We can also delay a promise function.
+You can also deprioritize a promise function to delay its execution:
 
 ```js
 import PQueue from 'p-queue';
@@ -272,7 +276,7 @@ queue.add(async () => '🦄', {priority: 0});
 
 queue.setPriority('🦀', -1);
 ```
-In above case, promise function with '🦀' executes last.
+Here, the promise function with id: '🦀' executes last.
 
 #### .pending
 

--- a/readme.md
+++ b/readme.md
@@ -137,11 +137,11 @@ Default: `0`
 
 Priority of operation. Operations with greater priority will be scheduled first.
 
-##### id
+##### index
 
 Type `string`
 
-Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned as an incrementing bigint starting from 1n.
+Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned an incrementing BigInt starting from `1n`.
 
 ##### signal
 
@@ -242,9 +242,9 @@ console.log(queue.sizeBy({priority: 0}));
 //=> 1
 ```
 
-#### .setPriority(id, priority)
+#### .setPriority(index, priority)
 
-Updates the priority of a promise function by its id, affecting its execution order. Requires a defined concurrency limit to take effect.
+Updates the priority of a promise function by its index, affecting its execution order. Requires a defined concurrency limit to take effect.
 
 For example, this can be used to prioritize a promise function to run earlier.
 
@@ -254,13 +254,13 @@ import PQueue from 'p-queue';
 const queue = new PQueue({concurrency: 1});
 
 queue.add(async () => '🦄', {priority: 1});
-queue.add(async () => '🦀', {priority: 0, id: '🦀'});
+queue.add(async () => '🦀', {priority: 0, index: '🦀'});
 queue.add(async () => '🦄', {priority: 1});
 queue.add(async () => '🦄', {priority: 1});
 
 queue.setPriority('🦀', 2);
 ```
-In this case, the promise function with id: '🦀' runs second.
+In this case, the promise function with index: '🦀' runs second.
 
 You can also deprioritize a promise function to delay its execution:
 
@@ -270,13 +270,13 @@ import PQueue from 'p-queue';
 const queue = new PQueue({concurrency: 1});
 
 queue.add(async () => '🦄', {priority: 1});
-queue.add(async () => '🦀', {priority: 1, id: '🦀'});
+queue.add(async () => '🦀', {priority: 1, index: '🦀'});
 queue.add(async () => '🦄');
 queue.add(async () => '🦄', {priority: 0});
 
 queue.setPriority('🦀', -1);
 ```
-Here, the promise function with id: '🦀' executes last.
+Here, the promise function with index: '🦀' executes last.
 
 #### .pending
 

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,7 @@ Default: `0`
 
 Priority of operation. Operations with greater priority will be scheduled first.
 
-##### index
+##### id
 
 Type `string`
 
@@ -242,9 +242,9 @@ console.log(queue.sizeBy({priority: 0}));
 //=> 1
 ```
 
-#### .setPriority(index, priority)
+#### .setPriority(id, priority)
 
-Updates the priority of a promise function by its index, affecting its execution order. Requires a defined concurrency limit to take effect.
+Updates the priority of a promise function by its id, affecting its execution order. Requires a defined concurrency limit to take effect.
 
 For example, this can be used to prioritize a promise function to run earlier.
 
@@ -254,13 +254,14 @@ import PQueue from 'p-queue';
 const queue = new PQueue({concurrency: 1});
 
 queue.add(async () => '🦄', {priority: 1});
-queue.add(async () => '🦀', {priority: 0, index: '🦀'});
+queue.add(async () => '🦀', {priority: 0, id: '🦀'});
 queue.add(async () => '🦄', {priority: 1});
 queue.add(async () => '🦄', {priority: 1});
 
 queue.setPriority('🦀', 2);
 ```
-In this case, the promise function with index: '🦀' runs second.
+
+In this case, the promise function with `id: '🦀'` runs second.
 
 You can also deprioritize a promise function to delay its execution:
 
@@ -270,13 +271,14 @@ import PQueue from 'p-queue';
 const queue = new PQueue({concurrency: 1});
 
 queue.add(async () => '🦄', {priority: 1});
-queue.add(async () => '🦀', {priority: 1, index: '🦀'});
+queue.add(async () => '🦀', {priority: 1, id: '🦀'});
 queue.add(async () => '🦄');
 queue.add(async () => '🦄', {priority: 0});
 
 queue.setPriority('🦀', -1);
 ```
-Here, the promise function with index: '🦀' executes last.
+
+Here, the promise function with `id: '🦀'` executes last.
 
 #### .pending
 

--- a/readme.md
+++ b/readme.md
@@ -236,6 +236,44 @@ console.log(queue.sizeBy({priority: 0}));
 //=> 1
 ```
 
+#### .setPriority(id, priority)
+
+Update priority of a known promise function, using the `id` identifier, and a priority value to override existing priority value. The updated value of priority ensures whether to execute this promise function sooner or later.
+
+Function works only when we specify a defined concurrency to change any priorities.
+
+For example, this can be used to make a promise function run earlier.
+
+```js
+import PQueue from 'p-queue';
+
+const queue = new PQueue({concurrency: 1});
+
+queue.add(async () => '🦄', {priority: 1});
+queue.add(async () => '🦀', {priority: 0, id: '🦀'});
+queue.add(async () => '🦄', {priority: 1});
+queue.add(async () => '🦄', {priority: 1});
+
+queue.setPriority('🦀', 2);
+```
+In above case, promise function with '🦀' executes second.
+
+We can also delay a promise function.
+
+```js
+import PQueue from 'p-queue';
+
+const queue = new PQueue({concurrency: 1});
+
+queue.add(async () => '🦄', {priority: 1});
+queue.add(async () => '🦀', {priority: 1, id: '🦀'});
+queue.add(async () => '🦄');
+queue.add(async () => '🦄', {priority: 0});
+
+queue.setPriority('🦀', -1);
+```
+In above case, promise function with '🦀' executes last.
+
 #### .pending
 
 Number of running items (no longer in the queue).

--- a/source/index.ts
+++ b/source/index.ts
@@ -43,6 +43,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 
 	readonly #throwOnTimeout: boolean;
 
+	/** use to assign a unique identifier to a promise function, if not explicitly specified */
 	#uidAssigner: number = 1;
 
 	/**
@@ -241,7 +242,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	async add<TaskResultType>(function_: Task<TaskResultType>, options?: Partial<EnqueueOptionsType>, uid?: string): Promise<TaskResultType | void>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: Partial<EnqueueOptionsType> = {}, uid?: string): Promise<TaskResultType | void> {
 		// incase uid is not defined
-		uid = (this.#uidAssigner++).toString();
+		!uid && (uid = (this.#uidAssigner++).toString());
 		options = {
 			timeout: this.timeout,
 			throwOnTimeout: this.#throwOnTimeout,

--- a/source/index.ts
+++ b/source/index.ts
@@ -232,7 +232,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
-	Updates the priority of a promise function by its id, affecting its execution order. Requires a defined concurrency limit to take effect.
+	Updates the priority of a promise function by its index, affecting its execution order. Requires a defined concurrency limit to take effect.
 
 	For example, this can be used to prioritize a promise function to run earlier.
 
@@ -242,13 +242,13 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	const queue = new PQueue({concurrency: 1});
 
 	queue.add(async () => '🦄', {priority: 1});
-	queue.add(async () => '🦀', {priority: 0, id: '🦀'});
+	queue.add(async () => '🦀', {priority: 0, index: '🦀'});
 	queue.add(async () => '🦄', {priority: 1});
 	queue.add(async () => '🦄', {priority: 1});
 
 	queue.setPriority('🦀', 2);
 	```
-	In this case, the promise function with id: '🦀' runs second.
+	In this case, the promise function with index: '🦀' runs second.
 
 	You can also deprioritize a promise function to delay its execution:
 
@@ -258,16 +258,16 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	const queue = new PQueue({concurrency: 1});
 
 	queue.add(async () => '🦄', {priority: 1});
-	queue.add(async () => '🦀', {priority: 1, id: '🦀'});
+	queue.add(async () => '🦀', {priority: 1, index: '🦀'});
 	queue.add(async () => '🦄');
 	queue.add(async () => '🦄', {priority: 0});
 
 	queue.setPriority('🦀', -1);
 	```
-	Here, the promise function with id: '🦀' executes last.
+	Here, the promise function with index: '🦀' executes last.
 	*/
-	setPriority(id: string, priority: number) {
-		this.#queue.setPriority(id, priority);
+	setPriority(index: string, priority: number) {
+		this.#queue.setPriority(index, priority);
 	}
 
 	/**
@@ -276,8 +276,8 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: {throwOnTimeout: true} & Exclude<EnqueueOptionsType, 'throwOnTimeout'>): Promise<TaskResultType>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options?: Partial<EnqueueOptionsType>): Promise<TaskResultType | void>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: Partial<EnqueueOptionsType> = {}): Promise<TaskResultType | void> {
-		// In case `id` is not defined.
-		options.id ??= (this.#idAssigner++).toString();
+		// In case `index` is not defined.
+		options.index ??= (this.#idAssigner++).toString();
 
 		options = {
 			timeout: this.timeout,

--- a/source/index.ts
+++ b/source/index.ts
@@ -43,8 +43,8 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 
 	readonly #throwOnTimeout: boolean;
 
-	/** Use to assign a unique identifier to a promise function, if not explicitly specified */
-	#idAssigner = 1;
+	// Use to assign a unique identifier to a promise function, if not explicitly specified
+	#idAssigner = 1n;
 
 	/**
 	Per-operation timeout in milliseconds. Operations fulfill once `timeout` elapses if they haven't already.
@@ -231,6 +231,9 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 		});
 	}
 
+	/**
+	Update priority of a known promise function, using the `id` identifier, and a priority value to override existing priority value. The updated value of priority ensures whether to execute this promise function sooner or later.
+	*/
 	setPriority(id: string, priority: number) {
 		this.#queue.setPriority(id, priority);
 	}
@@ -241,10 +244,8 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: {throwOnTimeout: true} & Exclude<EnqueueOptionsType, 'throwOnTimeout'>): Promise<TaskResultType>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options?: Partial<EnqueueOptionsType>): Promise<TaskResultType | void>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: Partial<EnqueueOptionsType> = {}): Promise<TaskResultType | void> {
-		// Incase id is not defined
-		if (options.id === undefined) {
-			options.id = (this.#idAssigner++).toString();
-		}
+		// In case `id` is not defined.
+		options.id ??= (this.#idAssigner++).toString();
 
 		options = {
 			timeout: this.timeout,

--- a/source/index.ts
+++ b/source/index.ts
@@ -232,7 +232,9 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
-	Update priority of a known promise function, using the `id` identifier, and a priority value to override existing priority value. The updated value of priority ensures whether to execute this promise function sooner or later.
+	Updates the priority of a promise function by its id, affecting its execution order. Requires a defined concurrency limit to take effect.
+
+	For example, this can be used to prioritize a promise function to run earlier.
 	*/
 	setPriority(id: string, priority: number) {
 		this.#queue.setPriority(id, priority);

--- a/source/index.ts
+++ b/source/index.ts
@@ -43,8 +43,8 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 
 	readonly #throwOnTimeout: boolean;
 
-	/** use to assign a unique identifier to a promise function, if not explicitly specified */
-	#uidAssigner: number = 1;
+	/** Use to assign a unique identifier to a promise function, if not explicitly specified */
+	#uidAssigner = 1;
 
 	/**
 	Per-operation timeout in milliseconds. Operations fulfill once `timeout` elapses if they haven't already.
@@ -238,11 +238,14 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	/**
 	Adds a sync or async task to the queue. Always returns a promise.
 	*/
-	async add<TaskResultType>(function_: Task<TaskResultType>, options: { throwOnTimeout: true } & Exclude<EnqueueOptionsType, 'throwOnTimeout'>, uid?: string): Promise<TaskResultType>;
+	async add<TaskResultType>(function_: Task<TaskResultType>, options: {throwOnTimeout: true} & Exclude<EnqueueOptionsType, 'throwOnTimeout'>, uid?: string): Promise<TaskResultType>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options?: Partial<EnqueueOptionsType>, uid?: string): Promise<TaskResultType | void>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: Partial<EnqueueOptionsType> = {}, uid?: string): Promise<TaskResultType | void> {
-		// incase uid is not defined
-		!uid && (uid = (this.#uidAssigner++).toString());
+		// Incase uid is not defined
+		if (uid === undefined) {
+			uid = (this.#uidAssigner++).toString();
+		}
+
 		options = {
 			timeout: this.timeout,
 			throwOnTimeout: this.#throwOnTimeout,
@@ -268,7 +271,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 						operation = Promise.race([operation, this.#throwOnAbort(options.signal)]);
 					}
 
-					uid && this.emit('started', uid);
+					this.emit('started', uid);
 					const result = await operation;
 					resolve(result);
 					this.emit('completed', result);

--- a/source/index.ts
+++ b/source/index.ts
@@ -235,6 +235,36 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	Updates the priority of a promise function by its id, affecting its execution order. Requires a defined concurrency limit to take effect.
 
 	For example, this can be used to prioritize a promise function to run earlier.
+
+	```js
+	import PQueue from 'p-queue';
+
+	const queue = new PQueue({concurrency: 1});
+
+	queue.add(async () => '🦄', {priority: 1});
+	queue.add(async () => '🦀', {priority: 0, id: '🦀'});
+	queue.add(async () => '🦄', {priority: 1});
+	queue.add(async () => '🦄', {priority: 1});
+
+	queue.setPriority('🦀', 2);
+	```
+	In this case, the promise function with id: '🦀' runs second.
+
+	You can also deprioritize a promise function to delay its execution:
+
+	```js
+	import PQueue from 'p-queue';
+
+	const queue = new PQueue({concurrency: 1});
+
+	queue.add(async () => '🦄', {priority: 1});
+	queue.add(async () => '🦀', {priority: 1, id: '🦀'});
+	queue.add(async () => '🦄');
+	queue.add(async () => '🦄', {priority: 0});
+
+	queue.setPriority('🦀', -1);
+	```
+	Here, the promise function with id: '🦀' executes last.
 	*/
 	setPriority(id: string, priority: number) {
 		this.#queue.setPriority(id, priority);

--- a/source/index.ts
+++ b/source/index.ts
@@ -232,7 +232,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	}
 
 	/**
-	Updates the priority of a promise function by its index, affecting its execution order. Requires a defined concurrency limit to take effect.
+	Updates the priority of a promise function by its id, affecting its execution order. Requires a defined concurrency limit to take effect.
 
 	For example, this can be used to prioritize a promise function to run earlier.
 
@@ -242,13 +242,14 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	const queue = new PQueue({concurrency: 1});
 
 	queue.add(async () => '🦄', {priority: 1});
-	queue.add(async () => '🦀', {priority: 0, index: '🦀'});
+	queue.add(async () => '🦀', {priority: 0, id: '🦀'});
 	queue.add(async () => '🦄', {priority: 1});
 	queue.add(async () => '🦄', {priority: 1});
 
 	queue.setPriority('🦀', 2);
 	```
-	In this case, the promise function with index: '🦀' runs second.
+
+	In this case, the promise function with `id: '🦀'` runs second.
 
 	You can also deprioritize a promise function to delay its execution:
 
@@ -258,16 +259,16 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	const queue = new PQueue({concurrency: 1});
 
 	queue.add(async () => '🦄', {priority: 1});
-	queue.add(async () => '🦀', {priority: 1, index: '🦀'});
+	queue.add(async () => '🦀', {priority: 1, id: '🦀'});
 	queue.add(async () => '🦄');
 	queue.add(async () => '🦄', {priority: 0});
 
 	queue.setPriority('🦀', -1);
 	```
-	Here, the promise function with index: '🦀' executes last.
+	Here, the promise function with `id: '🦀'` executes last.
 	*/
-	setPriority(index: string, priority: number) {
-		this.#queue.setPriority(index, priority);
+	setPriority(id: string, priority: number) {
+		this.#queue.setPriority(id, priority);
 	}
 
 	/**
@@ -276,8 +277,8 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: {throwOnTimeout: true} & Exclude<EnqueueOptionsType, 'throwOnTimeout'>): Promise<TaskResultType>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options?: Partial<EnqueueOptionsType>): Promise<TaskResultType | void>;
 	async add<TaskResultType>(function_: Task<TaskResultType>, options: Partial<EnqueueOptionsType> = {}): Promise<TaskResultType | void> {
-		// In case `index` is not defined.
-		options.index ??= (this.#idAssigner++).toString();
+		// In case `id` is not defined.
+		options.id ??= (this.#idAssigner++).toString();
 
 		options = {
 			timeout: this.timeout,

--- a/source/options.ts
+++ b/source/options.ts
@@ -69,6 +69,13 @@ export type QueueAddOptions = {
 	@default 0
 	*/
 	readonly priority?: number;
+	/**
+	Unique identifier for the promise function. This can be used to update priority, before it gets executed.
+
+	@default '1'
+
+	Value of `id` will be assigned using a bigint number assigner which increments for every new promise function with unspecified id
+	*/
 	id?: string;
 } & TaskOptions & TimeoutOptions;
 

--- a/source/options.ts
+++ b/source/options.ts
@@ -71,7 +71,7 @@ export type QueueAddOptions = {
 	readonly priority?: number;
 
 	/**
-	Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned as an incrementing bigint starting from 1n.   
+	Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned as an incrementing bigint starting from 1n.
 	*/
 	id?: string;
 } & TaskOptions & TimeoutOptions;

--- a/source/options.ts
+++ b/source/options.ts
@@ -73,7 +73,7 @@ export type QueueAddOptions = {
 	/**
 	Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned an incrementing BigInt starting from `1n`.
 	*/
-	index?: string;
+	id?: string;
 } & TaskOptions & TimeoutOptions;
 
 export type TaskOptions = {

--- a/source/options.ts
+++ b/source/options.ts
@@ -71,9 +71,9 @@ export type QueueAddOptions = {
 	readonly priority?: number;
 
 	/**
-	Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned as an incrementing bigint starting from 1n.
+	Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned an incrementing BigInt starting from `1n`.
 	*/
-	id?: string;
+	index?: string;
 } & TaskOptions & TimeoutOptions;
 
 export type TaskOptions = {

--- a/source/options.ts
+++ b/source/options.ts
@@ -70,11 +70,7 @@ export type QueueAddOptions = {
 	*/
 	readonly priority?: number;
 	/**
-	Unique identifier for the promise function. This can be used to update priority, before it gets executed.
-
-	@default '1'
-
-	Value of `id` will be assigned using a bigint number assigner which increments for every new promise function with unspecified id
+	Unique identifier for the promise function, used to update its priority before execution. If not specified, it is auto-assigned as an incrementing bigint starting from 1n.   
 	*/
 	id?: string;
 } & TaskOptions & TimeoutOptions;

--- a/source/options.ts
+++ b/source/options.ts
@@ -69,6 +69,7 @@ export type QueueAddOptions = {
 	@default 0
 	*/
 	readonly priority?: number;
+	id?: string;
 } & TaskOptions & TimeoutOptions;
 
 export type TaskOptions = {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -4,6 +4,7 @@ import {type QueueAddOptions} from './options.js';
 
 export type PriorityQueueOptions = {
 	priority?: number;
+	uid?: string;
 } & QueueAddOptions;
 
 export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOptions> {
@@ -30,6 +31,11 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 			(a: Readonly<PriorityQueueOptions>, b: Readonly<PriorityQueueOptions>) => b.priority! - a.priority!,
 		);
 		this.#queue.splice(index, 0, element);
+	}
+
+	prioritize(uid: string, priority?: number) {
+		const item = this.#queue.find((element: Readonly<PriorityQueueOptions>) => element.uid === uid);
+		item && (item.priority = priority || ((item.priority || 0) + 1));
 	}
 
 	dequeue(): RunFunction | undefined {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -40,11 +40,7 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 		}
 
 		const [item] = this.#queue.splice(existingIndex, 1);
-		if (item === undefined) {
-			throw new Error('Undefined Item - No promise function of specified id available in the queue.');
-		}
-
-		this.enqueue(item.run, {priority, id});
+		this.enqueue(item!.run, {priority, id});
 	}
 
 	dequeue(): RunFunction | undefined {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -17,7 +17,7 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 
 		const element = {
 			priority: options.priority,
-			index: options.index,
+			id: options.id,
 			run,
 		};
 
@@ -33,14 +33,14 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 		this.#queue.splice(index, 0, element);
 	}
 
-	setPriority(index: string, priority: number) {
-		const existingIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.index === index);
-		if (existingIndex === -1) {
-			throw new ReferenceError(`No promise function with the index "${index}" exists in the queue.`);
+	setPriority(id: string, priority: number) {
+		const index: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.id === id);
+		if (index === -1) {
+			throw new ReferenceError(`No promise function with the id "${id}" exists in the queue.`);
 		}
 
-		const [item] = this.#queue.splice(existingIndex, 1);
-		this.enqueue(item!.run, {priority, index});
+		const [item] = this.#queue.splice(index, 1);
+		this.enqueue(item!.run, {priority, id});
 	}
 
 	dequeue(): RunFunction | undefined {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -17,7 +17,7 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 
 		const element = {
 			priority: options.priority,
-			id: options.id,
+			index: options.index,
 			run,
 		};
 
@@ -33,14 +33,14 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 		this.#queue.splice(index, 0, element);
 	}
 
-	setPriority(id: string, priority: number) {
-		const existingIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.id === id);
+	setPriority(index: string, priority: number) {
+		const existingIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.index === index);
 		if (existingIndex === -1) {
-			throw new Error('Invalid Index - No promise function of specified id available in the queue.');
+			throw new ReferenceError(`No promise function with the index "${index}" exists in the queue.`);
 		}
 
 		const [item] = this.#queue.splice(existingIndex, 1);
-		this.enqueue(item!.run, {priority, id});
+		this.enqueue(item!.run, {priority, index});
 	}
 
 	dequeue(): RunFunction | undefined {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -4,7 +4,6 @@ import {type QueueAddOptions} from './options.js';
 
 export type PriorityQueueOptions = {
 	priority?: number;
-	uid?: string;
 } & QueueAddOptions;
 
 export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOptions> {
@@ -33,9 +32,9 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 		this.#queue.splice(index, 0, element);
 	}
 
-	prioritize(uid: string, priority?: number) {
-		const queueIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.uid === uid);
-		const [item] = this.#queue.splice(queueIndex, 1);
+	setPriority(id: string, priority?: number) {
+		const existingIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.id === id);
+		const [item] = this.#queue.splice(existingIndex, 1);
 		if (item === undefined) {
 			return;
 		}

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -17,10 +17,11 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 
 		const element = {
 			priority: options.priority,
+			id: options.id,
 			run,
 		};
 
-		if (this.size && this.#queue[this.size - 1]!.priority! >= options.priority!) {
+		if (this.size === 0 || this.#queue[this.size - 1]!.priority! >= options.priority!) {
 			this.#queue.push(element);
 			return;
 		}
@@ -32,15 +33,19 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 		this.#queue.splice(index, 0, element);
 	}
 
-	setPriority(id: string, priority?: number) {
+	setPriority(id: string, priority: number) {
 		const existingIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.id === id);
+		if (existingIndex === -1) {
+			throw new Error('Invalid Index - No promise function of specified id available in the queue.');
+		}
+
 		const [item] = this.#queue.splice(existingIndex, 1);
 		if (item === undefined) {
 			return;
 		}
 
-		item.priority = priority ?? ((item.priority ?? 0) + 1);
-		if (this.size && this.#queue[this.size - 1]!.priority! >= priority!) {
+		item.priority = priority;
+		if (this.size === 0 || this.#queue[this.size - 1]!.priority! >= priority) {
 			this.#queue.push(item);
 			return;
 		}

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -35,7 +35,7 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 
 	setPriority(id: string, priority: number) {
 		const existingIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.id === id);
-		if (existingIndex === -1 ) {
+		if (existingIndex === -1) {
 			throw new Error('Invalid Index - No promise function of specified id available in the queue.');
 		}
 

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -44,18 +44,7 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 			throw new Error('Undefined Item - No promise function of specified id available in the queue.');
 		}
 
-		item.priority = priority;
-		if (this.size === 0 || this.#queue[this.size - 1]!.priority! >= priority) {
-			this.#queue.push(item);
-			return;
-		}
-
-		const index = lowerBound(
-			this.#queue, item,
-			(a: Readonly<PriorityQueueOptions>, b: Readonly<PriorityQueueOptions>) => b.priority! - a.priority!,
-		);
-
-		this.#queue.splice(index, 0, item);
+		this.enqueue(item.run, {priority, id});
 	}
 
 	dequeue(): RunFunction | undefined {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -34,8 +34,24 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 	}
 
 	prioritize(uid: string, priority?: number) {
-		const item = this.#queue.find((element: Readonly<PriorityQueueOptions>) => element.uid === uid);
-		item && (item.priority = priority || ((item.priority || 0) + 1));
+		const queueIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.uid === uid);
+		const [item] = this.#queue.splice(queueIndex, 1);
+		if (item === undefined) {
+			return;
+		}
+
+		item.priority = priority ?? ((item.priority ?? 0) + 1);
+		if (this.size && this.#queue[this.size - 1]!.priority! >= priority!) {
+			this.#queue.push(item);
+			return;
+		}
+
+		const index = lowerBound(
+			this.#queue, item,
+			(a: Readonly<PriorityQueueOptions>, b: Readonly<PriorityQueueOptions>) => b.priority! - a.priority!,
+		);
+
+		this.#queue.splice(index, 0, item);
 	}
 
 	dequeue(): RunFunction | undefined {

--- a/source/priority-queue.ts
+++ b/source/priority-queue.ts
@@ -35,13 +35,13 @@ export default class PriorityQueue implements Queue<RunFunction, PriorityQueueOp
 
 	setPriority(id: string, priority: number) {
 		const existingIndex: number = this.#queue.findIndex((element: Readonly<PriorityQueueOptions>) => element.id === id);
-		if (existingIndex === -1) {
+		if (existingIndex === -1 ) {
 			throw new Error('Invalid Index - No promise function of specified id available in the queue.');
 		}
 
 		const [item] = this.#queue.splice(existingIndex, 1);
 		if (item === undefined) {
-			return;
+			throw new Error('Undefined Item - No promise function of specified id available in the queue.');
 		}
 
 		item.priority = priority;

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -5,5 +5,5 @@ export type Queue<Element, Options> = {
 	filter: (options: Readonly<Partial<Options>>) => Element[];
 	dequeue: () => Element | undefined;
 	enqueue: (run: Element, options?: Partial<Options>) => void;
-	setPriority: (id: string, priority: number) => void;
+	setPriority: (index: string, priority: number) => void;
 };

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -5,5 +5,5 @@ export type Queue<Element, Options> = {
 	filter: (options: Readonly<Partial<Options>>) => Element[];
 	dequeue: () => Element | undefined;
 	enqueue: (run: Element, options?: Partial<Options>) => void;
-	setPriority: (index: string, priority: number) => void;
+	setPriority: (id: string, priority: number) => void;
 };

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -5,4 +5,5 @@ export type Queue<Element, Options> = {
 	filter: (options: Readonly<Partial<Options>>) => Element[];
 	dequeue: () => Element | undefined;
 	enqueue: (run: Element, options?: Partial<Options>) => void;
+	prioritize: (uid: string, priority: number) => void;
 };

--- a/source/queue.ts
+++ b/source/queue.ts
@@ -5,5 +5,5 @@ export type Queue<Element, Options> = {
 	filter: (options: Readonly<Partial<Options>>) => Element[];
 	dequeue: () => Element | undefined;
 	enqueue: (run: Element, options?: Partial<Options>) => void;
-	prioritize: (uid: string, priority: number) => void;
+	setPriority: (id: string, priority: number) => void;
 };

--- a/test/test.ts
+++ b/test/test.ts
@@ -1141,40 +1141,16 @@ test('.setPriority() - execute a promise before planned', async t => {
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {}, 'snail');
+	}, {id: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {}, 'duck');
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {}, 'turtle');
-	queue.setPriority('turtle', 1);
-	await queue.onIdle();
-	t.deepEqual(result, ['🐌', '🐢', '🦆']);
-});
-
-test('started event to check when promise function is called', async t => {
-	const result: string[] = [];
-	const queue = new PQueue({concurrency: 1});
-	queue.add(async () => {
-		await delay(400);
-		result.push('🐌');
-	}, {}, '🐌');
-	queue.add(async () => {
-		await delay(400);
-		result.push('🦆');
-	}, {}, '🦆');
-	queue.add(async () => {
-		await delay(400);
-		result.push('🐢');
-	}, {}, '🐢');
-	queue.on('started', uid => {
-		if (uid === '🦆') {
-			t.deepEqual(result, ['🐌', '🐢']);
-		}
-	});
+	}, {id: '🐢'});
 	queue.setPriority('🐢', 1);
 	await queue.onIdle();
+	t.deepEqual(result, ['🐌', '🐢', '🦆']);
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -1141,15 +1141,15 @@ test('.setPriority() - execute a promise before planned', async t => {
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {index: '🐌'});
+	}, {id: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {index: '🐢'});
+	}, {id: '🐢'});
 	queue.setPriority('🐢', 1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🐢', '🦆']);
@@ -1161,27 +1161,27 @@ test('.setPriority() - execute a promise after planned', async t => {
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {index: '🐌'});
+	}, {id: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {index: '🐢'});
+	}, {id: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.setPriority('🐢', -1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '🦆', '🦆', '🦆', '🐢']);
@@ -1193,19 +1193,19 @@ test('.setPriority() - execute a promise before planned - concurrency 2', async 
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {index: '🐌'});
+	}, {id: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {index: '🐢'});
+	}, {id: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('⚡️');
-	}, {index: '⚡️'});
+	}, {id: '⚡️'});
 	queue.setPriority('⚡️', 1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '⚡️', '🐢']);
@@ -1217,23 +1217,23 @@ test('.setPriority() - execute a promise before planned - concurrency 3', async 
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {index: '🐌'});
+	}, {id: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {index: '🐢'});
+	}, {id: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('⚡️');
-	}, {index: '⚡️'});
+	}, {id: '⚡️'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦀');
-	}, {index: '🦀'});
+	}, {id: '🦀'});
 	queue.setPriority('🦀', 1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '🐢', '🦀', '⚡️']);
@@ -1245,30 +1245,30 @@ test('.setPriority() - execute a multiple promise before planned, with variable 
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {index: '🐌'});
+	}, {id: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {index: '🦆'});
+	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {index: '🐢'});
+	}, {id: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('⚡️');
-	}, {index: '⚡️'});
+	}, {id: '⚡️'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦀');
-	}, {index: '🦀'});
+	}, {id: '🦀'});
 	queue.setPriority('⚡️', 1);
 	queue.setPriority('🦀', 2);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '🦀', '⚡️', '🐢']);
 });
 
-test('.setPriority() - execute a promise before planned - concurrency 3 and unspecified `index`', async t => {
+test('.setPriority() - execute a promise before planned - concurrency 3 and unspecified `id`', async t => {
 	const result: string[] = [];
 	const queue = new PQueue({concurrency: 3});
 	queue.add(async () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1141,15 +1141,15 @@ test('.setPriority() - execute a promise before planned', async t => {
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {id: '🐌'});
+	}, {index: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {id: '🐢'});
+	}, {index: '🐢'});
 	queue.setPriority('🐢', 1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🐢', '🦆']);
@@ -1161,27 +1161,27 @@ test('.setPriority() - execute a promise after planned', async t => {
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {id: '🐌'});
+	}, {index: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {id: '🐢'});
+	}, {index: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.setPriority('🐢', -1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '🦆', '🦆', '🦆', '🐢']);
@@ -1193,19 +1193,19 @@ test('.setPriority() - execute a promise before planned - concurrency 2', async 
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {id: '🐌'});
+	}, {index: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {id: '🐢'});
+	}, {index: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('⚡️');
-	}, {id: '⚡️'});
+	}, {index: '⚡️'});
 	queue.setPriority('⚡️', 1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '⚡️', '🐢']);
@@ -1217,23 +1217,23 @@ test('.setPriority() - execute a promise before planned - concurrency 3', async 
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {id: '🐌'});
+	}, {index: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {id: '🐢'});
+	}, {index: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('⚡️');
-	}, {id: '⚡️'});
+	}, {index: '⚡️'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦀');
-	}, {id: '🦀'});
+	}, {index: '🦀'});
 	queue.setPriority('🦀', 1);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '🐢', '🦀', '⚡️']);
@@ -1245,30 +1245,30 @@ test('.setPriority() - execute a multiple promise before planned, with variable 
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐌');
-	}, {id: '🐌'});
+	}, {index: '🐌'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦆');
-	}, {id: '🦆'});
+	}, {index: '🦆'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🐢');
-	}, {id: '🐢'});
+	}, {index: '🐢'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('⚡️');
-	}, {id: '⚡️'});
+	}, {index: '⚡️'});
 	queue.add(async () => {
 		await delay(400);
 		result.push('🦀');
-	}, {id: '🦀'});
+	}, {index: '🦀'});
 	queue.setPriority('⚡️', 1);
 	queue.setPriority('🦀', 2);
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🦆', '🦀', '⚡️', '🐢']);
 });
 
-test('.setPriority() - execute a promise before planned - concurrency 3 and unspecified `id`', async t => {
+test('.setPriority() - execute a promise before planned - concurrency 3 and unspecified `index`', async t => {
 	const result: string[] = [];
 	const queue = new PQueue({concurrency: 3});
 	queue.add(async () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1155,7 +1155,7 @@ test('.setPriority() - execute a promise before planned', async t => {
 	t.deepEqual(result, ['🐌', '🐢', '🦆']);
 });
 
-test.failing('.setPriority() - with invalid "id"', async t => {
+test('.setPriority() - execute a promise after planned', async t => {
 	const result: string[] = [];
 	const queue = new PQueue({concurrency: 1});
 	queue.add(async () => {
@@ -1168,9 +1168,131 @@ test.failing('.setPriority() - with invalid "id"', async t => {
 	}, {id: '🦆'});
 	queue.add(async () => {
 		await delay(400);
+		result.push('🦆');
+	}, {id: '🦆'});
+	queue.add(async () => {
+		await delay(400);
 		result.push('🐢');
 	}, {id: '🐢'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦆');
+	}, {id: '🦆'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦆');
+	}, {id: '🦆'});
+	queue.setPriority('🐢', -1);
+	await queue.onIdle();
+	t.deepEqual(result, ['🐌', '🦆', '🦆', '🦆', '🦆', '🐢']);
+});
+
+test('.setPriority() - execute a promise before planned - concurrency 2', async t => {
+	const result: string[] = [];
+	const queue = new PQueue({concurrency: 2});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐌');
+	}, {id: '🐌'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦆');
+	}, {id: '🦆'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐢');
+	}, {id: '🐢'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('⚡️');
+	}, {id: '⚡️'});
 	queue.setPriority('⚡️', 1);
 	await queue.onIdle();
-	t.deepEqual(result, ['🐌', '🐢', '🦆']);
+	t.deepEqual(result, ['🐌', '🦆', '⚡️', '🐢']);
 });
+
+test('.setPriority() - execute a promise before planned - concurrency 3', async t => {
+	const result: string[] = [];
+	const queue = new PQueue({concurrency: 3});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐌');
+	}, {id: '🐌'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦆');
+	}, {id: '🦆'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐢');
+	}, {id: '🐢'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('⚡️');
+	}, {id: '⚡️'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦀');
+	}, {id: '🦀'});
+	queue.setPriority('🦀', 1);
+	await queue.onIdle();
+	t.deepEqual(result, ['🐌', '🦆', '🐢', '🦀', '⚡️']);
+});
+
+test('.setPriority() - execute a multiple promise before planned, with variable priority', async t => {
+	const result: string[] = [];
+	const queue = new PQueue({concurrency: 2});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐌');
+	}, {id: '🐌'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦆');
+	}, {id: '🦆'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐢');
+	}, {id: '🐢'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('⚡️');
+	}, {id: '⚡️'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦀');
+	}, {id: '🦀'});
+	queue.setPriority('⚡️', 1);
+	queue.setPriority('🦀', 2);
+	await queue.onIdle();
+	t.deepEqual(result, ['🐌', '🦆', '🦀', '⚡️', '🐢']);
+});
+
+test('.setPriority() - execute a promise before planned - concurrency 3 and unspecified `id`', async t => {
+	const result: string[] = [];
+	const queue = new PQueue({concurrency: 3});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐌');
+	});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦆');
+	});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐢');
+	});
+	queue.add(async () => {
+		await delay(400);
+		result.push('⚡️');
+	});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦀');
+	});
+	queue.setPriority('5', 1);
+	await queue.onIdle();
+	t.deepEqual(result, ['🐌', '🦆', '🐢', '🦀', '⚡️']);
+});
+

--- a/test/test.ts
+++ b/test/test.ts
@@ -1154,3 +1154,23 @@ test('.setPriority() - execute a promise before planned', async t => {
 	await queue.onIdle();
 	t.deepEqual(result, ['🐌', '🐢', '🦆']);
 });
+
+test.failing('.setPriority() - with invalid "id"', async t => {
+	const result: string[] = [];
+	const queue = new PQueue({concurrency: 1});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐌');
+	}, {id: '🐌'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🦆');
+	}, {id: '🦆'});
+	queue.add(async () => {
+		await delay(400);
+		result.push('🐢');
+	}, {id: '🐢'});
+	queue.setPriority('⚡️', 1);
+	await queue.onIdle();
+	t.deepEqual(result, ['🐌', '🐢', '🦆']);
+});


### PR DESCRIPTION
Fixes #208 - add a `uid` to track the promise functions and update the priority on any promise.
also add a new event `started` to notify when a promise function is executed. 