### PR TITLE
Don't count aborted jobs in `intervalCount`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -289,10 +289,10 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 		return new Promise((resolve, reject) => {
 			this.#queue.enqueue(async () => {
 				this.#pending++;
-				this.#intervalCount++;
 
 				try {
 					options.signal?.throwIfAborted();
+					this.#intervalCount++;
 
 					let operation = function_({signal: options.signal});
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -1116,6 +1116,25 @@ test('should pass AbortSignal instance to job', async t => {
 	}, {signal: controller.signal});
 });
 
+test('aborted jobs do not use interval cap', async t => {
+	const queue = new PQueue({
+		concurrency: 1,
+		interval: 100,
+		intervalCap: 1,
+	});
+	const controller = new AbortController();
+
+	for (let i = 0; i < 5; i++) {
+		queue.add(() => null, {signal: controller.signal}).catch(() => null);
+	}
+
+	queue.add(() => null);
+
+	controller.abort();
+	await delay(150);
+	t.is(queue.size, 0);
+});
+
 test('aborting multiple jobs at the same time', async t => {
 	const queue = new PQueue({concurrency: 1});
 


### PR DESCRIPTION
This fixes #219 without bothering to literally remove items from the queue, and instead simply not incrementing the interval count when the signal was previously aborted.