### PR TITLE
Add `.onPendingZero()` method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,18 @@ The difference with `.onEmpty` is that `.onIdle` guarantees that all work from t
 > [!NOTE]
 > The promise returned by `.onIdle()` resolves **once** when the queue becomes idle. If you want to be notified every time the queue becomes idle, use the `idle` event instead: `queue.on('idle', () => {})`.
 
+#### .onPendingZero()
+
+Returns a promise that settles when all currently running tasks have completed; `queue.pending === 0`.
+
+The difference with `.onIdle` is that `.onPendingZero` only waits for currently running tasks to finish, ignoring queued tasks. This is useful when you want to drain in-flight tasks before mutating shared state.
+
+```js
+queue.pause();
+await queue.onPendingZero();
+// All running tasks have finished, though the queue may still have items
+```
+
 #### .onSizeLessThan(limit)
 
 Returns a promise that settles when the queue size is less than the given limit: `queue.size < limit`.
@@ -393,6 +405,12 @@ Useful if you for example add additional items at a later time.
 Emitted every time the queue becomes empty and all promises have completed; `queue.size === 0 && queue.pending === 0`.
 
 The difference with `empty` is that `idle` guarantees that all work from the queue has finished. `empty` merely signals that the queue is empty, but it could mean that some promises haven't completed yet.
+
+#### pendingZero
+
+Emitted every time the number of running tasks becomes zero; `queue.pending === 0`.
+
+The difference with `idle` is that `pendingZero` is emitted even when the queue still has items waiting to run, whereas `idle` requires both an empty queue and no pending tasks.
 
 ```js
 import delay from 'delay';

--- a/source/index.ts
+++ b/source/index.ts
@@ -8,7 +8,7 @@ type Task<TaskResultType> =
 	| ((options: TaskOptions) => PromiseLike<TaskResultType>)
 	| ((options: TaskOptions) => TaskResultType);
 
-type EventName = 'active' | 'idle' | 'empty' | 'add' | 'next' | 'completed' | 'error';
+type EventName = 'active' | 'idle' | 'empty' | 'add' | 'next' | 'completed' | 'error' | 'pendingZero';
 
 /**
 Promise queue with concurrency control.
@@ -100,6 +100,11 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 
 	#next(): void {
 		this.#pending--;
+
+		if (this.#pending === 0) {
+			this.emit('pendingZero');
+		}
+
 		this.#tryToStartAnother();
 		this.emit('next');
 	}
@@ -457,6 +462,19 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 		}
 
 		await this.#onEvent('idle');
+	}
+
+	/**
+	The difference with `.onIdle` is that `.onPendingZero` only waits for currently running tasks to finish, ignoring queued tasks.
+
+	@returns A promise that settles when all currently running tasks have completed; `queue.pending === 0`.
+	*/
+	async onPendingZero(): Promise<void> {
+		if (this.#pending === 0) {
+			return;
+		}
+
+		await this.#onEvent('pendingZero');
 	}
 
 	async #onEvent(event: EventName, filter?: () => boolean): Promise<void> {


### PR DESCRIPTION
Fixes #96

This provides a way to wait for all currently running tasks to finish while ignoring queued tasks. Fills the gap between `onEmpty()` (queue size = 0) and `onIdle()` (queue empty + no running tasks).

A comon use case: draining in-flight tasks before mutating shared state.