### PR TITLE
docs: clarify autoStart README wording

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ await queue.add(() => slowTask(), {timeout: 10000});
 Type: `boolean`\
 Default: `true`
 
-Whether queue tasks within concurrency limit, are auto-executed as soon as they're added.
+Whether queue tasks within the concurrency limit are auto-executed as soon as they're added.
 
 ##### queueClass
 


### PR DESCRIPTION
## Summary
- clarify the autoStart sentence in the README

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- CONTRIBUTING: none found in the repo root or .github on main
- PR template: none found in the repo root or .github on main

## Validation
- Not run (docs-only change)
