### PR TITLE
fix: export PriorityQueue to fix declaration emit for consumers

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -961,6 +961,7 @@ export default class PQueue<QueueType extends Queue<RunFunction, EnqueueOptionsT
 }
 
 export type {Queue} from './queue.js';
+export {default as PriorityQueue} from './priority-queue.js';
 export {type QueueAddOptions, type Options} from './options.js';
 
 /**


### PR DESCRIPTION
`PriorityQueue` is used as the default generic type parameter of PQueue, but is not re-exported from the package. This causes TypeScript's declaration emit (--declaration) to fail for any consumer that exposes a PQueue instance in their public API, because TypeScript cannot reference `PriorityQueue` through a portable import path.