### PR TITLE
docs: fix duplicate `const results` declaration in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -935,8 +935,11 @@ const results = await Promise.all(
 	tasks.map(task => queue.add(task))
 );
 // results = [result1, result2, result3] ✅ Always in input order
+```
 
-// Or more concisely:
+Or more concisely:
+
+```js
 const urls = ['url1', 'url2', 'url3'];
 const results = await Promise.all(
 	urls.map(url => queue.add(() => fetch(url)))


### PR DESCRIPTION

**Repo:** sindresorhus/p-queue (⭐ 3000)
**Type:** docs
**Files changed:** 1
**Lines:** +4/-1

## What
The "How do I get results in the order they were added?" FAQ section in `readme.md` contained two consecutive `const results = ...` declarations within the same code block. In real JS that block would throw `SyntaxError: Identifier 'results' has already been declared`. Split the two examples into separate fenced code blocks so each stands on its own as a runnable snippet.

## Why
Readme examples double as copy-paste starter code; an example that cannot run undermines trust and confuses readers. The fix keeps both illustrations (direct mapping and URL mapping) but scopes each to its own block.

## Testing
Purely a docs/markdown change — no test surface. Verified by rendering the markdown and confirming the two code blocks are distinct and each is valid JS on its own.

## Risk
Low — documentation-only; no source, tests, or exports touched.
