### PR TITLE
fix: support ES2020 TypeScript consumers

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference -- Needed in emitted declarations for p-timeout's ErrorOptions type.
+/// <reference lib="es2022.error" preserve="true" />
 import {EventEmitter} from 'eventemitter3';
 import pTimeout from 'p-timeout';
 import {type Queue, type RunFunction} from './queue.js';


### PR DESCRIPTION
## Summary

Fixes TypeScript consumers that compile with `target: "ES2020"` or `"ES2021"` and `skipLibCheck: false`.

`p-queue` re-exports `TimeoutError` from `p-timeout`. That makes TypeScript load `p-timeout` declarations when checking `p-queue`, even if the user never imports `p-timeout` directly.

`p-timeout` uses `ErrorOptions`, which comes from `ES2022.Error`. ES2020 projects may not have that lib loaded, so a plain `import PQueue from 'p-queue'` can fail with:

```text
Cannot find name 'ErrorOptions'
```

## Why fix this here?
The root type is in p-timeout, so an upstream fix there would also be useful. But p-queue re-exports that type as part of its public declaration surface, so p-queue consumers can hit the error without depending on or importing p-timeout.

This local fix shields p-queue users now and remains harmless if p-timeout later adds the same reference.